### PR TITLE
Address minor issues with files/handshake.txt

### DIFF
--- a/files/handshake.txt
+++ b/files/handshake.txt
@@ -172,8 +172,8 @@ all possible short names in existence, monopolizing the network. This would
 severely reduce the usefulness as one or a handful of parties monopolize the
 resources. To correctly mitigate this problem, a currency native to the
 blockchain is necessary to create a cost function for the names. When a name is
-auction and sold, the coins are permanently destroyed from the system. Without a
-cost, there is no cost to spamming and a single party owning everything. A
+auctioned and sold, the coins are permanently destroyed from the system. Without
+a cost, there is no cost to spamming and a single party owning everything. A
 native coin is necessary, as a dollar-pegged coin would depend on an external
 environment and have a trusted 3rd party operate as a gatekeeper to the system,
 whereas a native coin would not depend on any single trusted third party.
@@ -412,7 +412,7 @@ by Bram Cohen[merkleset].
 
 Later iterations of our data structure began storing colliding prefix bits on
 internal nodes, resulting in a base-2 merkelized radix tree similar to the
-_Merklix Tree_[merklix-1][merklix-2] proposed by Amaury Séchet.
+_Merklix Tree_[merklix-1][merklix-2] proposed by Amaury SÃ©chet.
 
 As the backbone of our FFMT, we propose one of the two aforementioned data
 structures.
@@ -906,7 +906,7 @@ occur at the output level.
 ## Covenants
 
 _Bitcoin Covenants_, first explored by Maxwell[maxwell-1][maxwell-2] and later
-formally described by Möser et al[covenants], are a form of smart contracts
+formally described by MÃ¶ser et al[covenants], are a form of smart contracts
 that exist on a UTXO-based blockchain such as Bitcoin. The word "covenant"
 itself refers to a legally binding covenant, in which a party agrees to refrain
 from or participate in a certain action in the future. Covenants, at their most
@@ -1808,13 +1808,13 @@ These allocations are this paper's proposed allocations, and the Handshake
 community will ultimately determine the final allocation in mainnet.
 
 A total of 1,360,000,000 coins are minted in the genesis block to be distributed
-to relevant stakeholders
+to relevant stakeholders:
 
 ## Pre-Launch Blockchain Development - 7.5%
 
 This allocation goes to fund development across various stakeholders who have
 been involved with creation of this project. These coins are used to pay for
-work prior to mainnet launch and is the only source of development funds. A
+work prior to mainnet launch and is the only source of development funds. An
 iterated tit-for-tat game exists whereby there is self-interested benefit for
 giving away value ("the more I give away, the more value I accrue") across
 many projects and development teams emulating this model.
@@ -2021,7 +2021,7 @@ due to transaction costs, it is often cheaper to conduct transactions within an
 organization rather than between organizations as intra-organizational goals are
 aligned, rather than inter-organizational goals, hence the high transaction
 costs from due diligence with external parties. Firms become large fundamentally
-due to trust and ensures everyone is rallying to the same cause. Power
+due to trust and ensure everyone is rallying to the same cause. Power
 centralizes into the agents of these firms, we believe we can do better with
 technology.
 
@@ -2038,13 +2038,13 @@ The purpose of smart contracts[smartcontracts] is that it allows the
 principal to also be the agent, as computation can allow one to read the code
 once and ensure that the code is being followed, significantly reducing
 potential information costs. However, smart contracts do not solve social
-coordination inherently, they merely make it cheap for those whom have already
+coordination inherently, they merely make it cheap for those who have already
 agreed with what is being coordinated.
 
-By constructing a capital structure without obligations (gift economies), method
-is proposed to create immensely valuable social structures with proper social
-incentives for restructuring the current organizational centers of power within
-society by participants of this gift economy.
+By constructing a capital structure without obligations (gift economies), a
+method is proposed to create immensely valuable social structures with proper
+social incentives for restructuring the current organizational centers of power
+within society by participants of this gift economy.
 
 ## Inability to Verify Actions
 
@@ -2066,10 +2066,11 @@ until now. There have been prior work around reward mechanisms in exchange for
 production in Commons-Based Crypto Currencies[primaveradefilippi], and much
 exploration has occurred in understanding the implications of the blockchain
 having no single owner (hence similarity to the notion of a commons), but
-payment for free and open source code are primarily within the context of payment for
-proposed acceptable work in exchange for cryptocurrencies. Instead, this project
-is about ensuring that free and open source developers are the majority owners of the
-system without any direct contractual expectation of return or work.
+payment for free and open source code are primarily within the context of
+payment for proposed acceptable work in exchange for cryptocurrencies. Instead,
+this project is about ensuring that free and open source developers are the
+majority owners of the system without any direct contractual expectation of
+return or work.
 
 Previously, FOSS developers have been rewarded by working in large
 companies such as Red Hat Software who are able to evaluate payment towards end
@@ -2101,7 +2102,7 @@ difficult to persuade riders to participate if there's insufficient drivers
 (long wait times), and difficult to persuade drivers on the platform if there's
 insufficient riders (low revenue). One of the earliest efforts for resolving
 this two-sided marketplace problem for internet services was initiated by
-Paypal, which resolved a side of the marketplace by directly giving money to new
+PayPal, which resolved a side of the marketplace by directly giving money to new
 users of PayPal.
 
 Overcoming two-sided marketplaces traditionally has required significant capital
@@ -2150,7 +2151,8 @@ humanity, and may be an exploration in a different model for development.
 There are no guarantees provided by the Handshake community developers past and
 present, including continued development and leadership. This document is
 illustrative and the de-facto community standards are the primary source. All
-contents of this document is subject to change according to community consensus.
+contents of this document are subject to change according to community
+consensus.
 
 No guarantees are provided with regards to functionality of the naming and
 auction system, including renewal availability, fees, or block availability in


### PR DESCRIPTION
Address minor issues with the paper at `files/handshake.txt`:

* Fix what look like typos to me. I'm not an expert editor so I'd check these changes carefully to be sure you agree.

* Consistently hard wrap to 80 characters in body. Previously almost every line was hard wrapped to 80 characters, so I assume this is the intent.

* Make the document valid UTF-8. This is the encoding required by the header at `https://handshake-org.github.io/files/handshake.txt`: `Content-Type: text/plain; charset=utf-8`. Previously some accent marks were not valid UTF-8. Validity was checked with ` iconv -f UTF-8 files/handshake.txt > /dev/null` on Mac.
