### PR TITLE
update package manager

### DIFF
--- a/src/guides/linux-install.md
+++ b/src/guides/linux-install.md
@@ -21,6 +21,7 @@ but should work in theory.
 - node.js
 - git
 ```
+$ curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 $ sudo apt install nodejs git
 ```
 


### PR DESCRIPTION
Without this, when trying to install on Ubuntu the version of node that is installed is older and the `npm install` broke. Adding this fixed it by getting node version 8.x. 

Alternatively, this can be used instead for node 10.x
```
curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
```