### PR TITLE
Fix typo in linux-install guide.

### DIFF
--- a/guides/linux-install.html
+++ b/guides/linux-install.html
@@ -74,7 +74,7 @@
 $ cd hsd
 $ npm install --production</code></pre>
 <h4 id="start-on-testnet">Start (on testnet)</h4>
-<pre><code>$ ./hsd/bin/hsd --daemon --no-auth</code></pre>
+<pre><code>$ ./bin/hsd --daemon --no-auth</code></pre>
 <p><br/></p>
 <h2 id="hnsd-installation-instructions"><code>hnsd</code> Installation Instructions</h2>
 <h4 id="install-dependencies-1">Install dependencies</h4>


### PR DESCRIPTION
If user follows the instructions as they are written,
no need to specify the "hsd" folder when executing the node.