### PR TITLE
Enable overwriting to work

### DIFF
--- a/src/guides/win-install.md
+++ b/src/guides/win-install.md
@@ -77,7 +77,7 @@ $ rm *.tgz
 $ cd bcrypto
 ```
 - Go thru and edit package.json in root `hsd/` folder to use file: of the above.
-- Edit binding.gyp: `"<!(bash -c \"python -c 'from __future__ import print_function; import sys; print(sys.byteorder)'\")",`
+- Edit binding.gyp: `"<!(bash -c \"python -c \"from __future__ import print_function; import sys; print(sys.byteorder)\"\")",`
 - Continue
 ```
 $ cd ..


### PR DESCRIPTION
When I overwrite below text
"<!(bash -c \"python -c 'from __future__ import print_function; import sys; print(sys.byteorder)'\")",
then, error was output :
  File "<string>", line 1
    'from
        ^
SyntaxError: EOL while scanning string literal

And I replaced ' to \" , it worked.