### PR TITLE
guides/config: replace BCOIN with HSD for env vars

### DIFF
--- a/guides/config.html
+++ b/guides/config.html
@@ -180,7 +180,7 @@ http-host: 0.0.0.0</code></pre>
 <p>Example using CLI options:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode bash"><code class="sourceCode bash"><a class="sourceLine" id="cb4-1" data-line-number="1">$ <span class="ex">./bin/hsd</span> --network=testnet --http-host=0.0.0.0 --wallet-http-host=0.0.0.0 --wallet-api-key=hunter2 --wallet-wallet-auth=true</a></code></pre></div>
 <p>Example using ENV:</p>
-<div class="sourceCode" id="cb5"><pre class="sourceCode bash"><code class="sourceCode bash"><a class="sourceLine" id="cb5-1" data-line-number="1">$ <span class="va">BCOIN_NETWORK=</span>testnet <span class="va">BCOIN_HTTP_HOST=</span>0.0.0.0 <span class="va">BCOIN_WALLET_HTTP_HOST=</span>0.0.0.0 <span class="va">BCOIN_WALLET_API_KEY=</span>hunter2 <span class="va">BCOIN_WALLET_WALLET_AUTH=</span>true <span class="ex">./bin/hsd</span></a></code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode bash"><code class="sourceCode bash"><a class="sourceLine" id="cb5-1" data-line-number="1">$ <span class="va">HSD_NETWORK=</span>testnet <span class="va">HSD_HTTP_HOST=</span>0.0.0.0 <span class="va">HSD_WALLET_HTTP_HOST=</span>0.0.0.0 <span class="va">HSD_WALLET_API_KEY=</span>hunter2 <span class="va">HSD_WALLET_WALLET_AUTH=</span>true <span class="ex">./bin/hsd</span></a></code></pre></div>
 <h3 id="hsd-client">hsd client:</h3>
 <ul>
 <li><code>node-host</code>: Location of hsd node HTTP server (default: localhost).</li>

--- a/src/guides/config.md
+++ b/src/guides/config.md
@@ -137,7 +137,7 @@ $ ./bin/hsd --network=testnet --http-host=0.0.0.0 --wallet-http-host=0.0.0.0 --w
 
 Example using ENV:
 ```bash
-$ BCOIN_NETWORK=testnet BCOIN_HTTP_HOST=0.0.0.0 BCOIN_WALLET_HTTP_HOST=0.0.0.0 BCOIN_WALLET_API_KEY=hunter2 BCOIN_WALLET_WALLET_AUTH=true ./bin/hsd
+$ HSD_NETWORK=testnet HSD_HTTP_HOST=0.0.0.0 HSD_WALLET_HTTP_HOST=0.0.0.0 HSD_WALLET_API_KEY=hunter2 HSD_WALLET_WALLET_AUTH=true ./bin/hsd
 ```
 
 ### hsd client:


### PR DESCRIPTION
Found a copy and paste error in the docs, the `BCOIN` prefix is being used for environment variables instead of `HSD`