### PR TITLE
Update claim process maturity requirements

### DIFF
--- a/guides/claims.html
+++ b/guides/claims.html
@@ -96,7 +96,7 @@ example.com. 1800 IN RRSIG TXT 5 2 1800 20190615140933 20180615131108 ...</code>
 <p>The ZSK which signs our TXT record must be signed by our zone’s KSK. As per the typical DNSSEC setup, our zone’s KSK must be committed as a DS record in the parent zone.</p>
 <p>Once our proof is published on the DNS layer, we can use <code>sendclaim</code> to crawl the relevant zones and create the proof.</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1"></a>$ <span class="ex">hsw-cli</span> rpc sendclaim example</span></code></pre></div>
-<p>This will create and broadcast the proof to all of your peers, ultimately ending up in a miner’s mempool. Your claim should be mined within 5-20 minutes. Once mined, you must wait 400 blocks before your claim is considered “mature”.</p>
+<p>This will create and broadcast the proof to all of your peers, ultimately ending up in a miner’s mempool. Your claim should be mined within 5-20 minutes. Once mined, you must wait 4320 blocks before your claim is considered “mature”.</p>
 <p>Once the claim has reached maturity, you are able to bypass the auction process by calling <code>sendupdate</code> on your claimed name.</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1"></a>$ <span class="ex">hsw-cli</span> rpc sendupdate example \</span>
 <span id="cb4-2"><a href="#cb4-2"></a>  <span class="st">&#39;{&quot;ttl&quot;:3600,&quot;canonical&quot;:&quot;icanhazip.com.&quot;}&#39;</span></span></code></pre></div>


### PR DESCRIPTION
Per https://github.com/handshake-org/hsd/issues/103 and https://github.com/handshake-org/hsd/blob/61defcc4c930ece17d80056885c035e322dbebac/lib/protocol/networks.js#L274 the maturity requirements for the claim process has been increased to 30 days, or 4320 block.s