### PR TITLE
node rpc: add getdnssecproof

### DIFF
--- a/api-docs/index.html
+++ b/api-docs/index.html
@@ -6874,8 +6874,8 @@ hsd-cli rpc generatetoaddress <span class="nv">$numblocks</span> <span class="nv
 </code></pre><pre class="highlight shell tab-shell--vars"><code><span class="nv">name</span><span class="o">=</span><span class="s1">'foo.bar'</span>;
 </code></pre><pre class="highlight shell tab-shell--cli"><code>hsd-rpc getdnssecproof <span class="s2">"</span><span class="nv">$name</span><span class="s2">"</span>
 </code></pre><pre class="highlight shell tab-shell--curl"><code>curl <span class="nv">$url</span> <span class="se">\</span>
-  -X POST <span class="se">\</span>
-  --data <span class="s1">'{ "method": "getdnssecproof", "params": ["$name"] }'</span>
+    -X POST <span class="se">\</span>
+    --data <span class="s1">'{"method":"getdnssecproof","params":["'</span><span class="nv">$name</span><span class="s1">'"]}'</span>
 </code></pre><pre class="highlight javascript tab-javascript"><code><span class="kr">const</span> <span class="p">{</span><span class="nx">NodeClient</span><span class="p">}</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'hs-client'</span><span class="p">);</span>
 <span class="kr">const</span> <span class="p">{</span><span class="nx">Network</span><span class="p">}</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'hsd'</span><span class="p">);</span>
 <span class="kr">const</span> <span class="nx">network</span> <span class="o">=</span> <span class="nx">Network</span><span class="p">.</span><span class="nx">get</span><span class="p">(</span><span class="s1">'regtest'</span><span class="p">);</span>
@@ -6901,7 +6901,7 @@ This is the same proof that is included in a name claim. See
 the <a href="#sendclaim">sendclaim</a> RPC method to build a transaction that includes
 the DNSSEC ownership proof. The <code>estimate</code> param is used to
 validate the proof. If set to <code>false</code>, it will strictly require
-the proof to be valid. If set to <code>true</code>, the proof will be build
+the proof to be valid. If set to <code>true</code>, the proof will be built
 and returned to the caller, even if it is invalid. The default
 value for <code>estimate</code> is <code>false</code>.</p>
 
@@ -6910,7 +6910,7 @@ a DNSSEC proof. Each parent/child zone must operate through a series
 of <code>DS-&gt;DNSKEY</code> relationships, no <code>CNAME</code>s or wildcards are allowed,
 each label separation (<code>.</code>) must behave like a zone cut (with an
 appropriate child zone referral) and weak cryptography is not allowed.
-This means that <code>SHA1</code> digests for <code>DS</code> hashes are not allowed,
+This means that SHA1 digests for <code>DS</code> hashes are not allowed,
 and RSA-1024 is subject to be disabled via soft-fork.</p>
 <h3 id='params-8'>Params</h3>
 <table><thead>
@@ -6932,7 +6932,7 @@ and RSA-1024 is subject to be disabled via soft-fork.</p>
 </tr>
 <tr>
 <td>verbose</td>
-<td>false</td>
+<td>true</td>
 <td>Returns hex when false</td>
 </tr>
 </tbody></table>

--- a/api-docs/index.html
+++ b/api-docs/index.html
@@ -6870,12 +6870,12 @@ hsd-cli rpc generatetoaddress <span class="nv">$numblocks</span> <span class="nv
 <td>raw serialized hex-string</td>
 </tr>
 </tbody></table>
-<h2 id='getdnssecproof'>getdnssecproof</h2><pre class="highlight shell tab-shell--cli"><code>hsd-rpc getdnssecproof &lt;domain-name&gt;
-</code></pre><pre class="highlight shell tab-shell--curl"><code><span class="nv">domain_name</span><span class="o">=</span>foo.bar
-
-curl <span class="nv">$url</span> <span class="se">\</span>
+<h2 id='getdnssecproof'>getdnssecproof</h2><pre class="highlight javascript tab-javascript"><code><span class="kd">let</span> <span class="nx">name</span><span class="p">;</span>
+</code></pre><pre class="highlight shell tab-shell--vars"><code><span class="nv">name</span><span class="o">=</span><span class="s1">'foo.bar'</span>;
+</code></pre><pre class="highlight shell tab-shell--cli"><code>hsd-rpc getdnssecproof <span class="s2">"</span><span class="nv">$name</span><span class="s2">"</span>
+</code></pre><pre class="highlight shell tab-shell--curl"><code>curl <span class="nv">$url</span> <span class="se">\</span>
   -X POST <span class="se">\</span>
-  --data <span class="s1">'{ "method": "getdnssecproof", "params": ["$domain_name"] }'</span>
+  --data <span class="s1">'{ "method": "getdnssecproof", "params": ["$name"] }'</span>
 </code></pre><pre class="highlight javascript tab-javascript"><code><span class="kr">const</span> <span class="p">{</span><span class="nx">NodeClient</span><span class="p">}</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'hs-client'</span><span class="p">);</span>
 <span class="kr">const</span> <span class="p">{</span><span class="nx">Network</span><span class="p">}</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'hsd'</span><span class="p">);</span>
 <span class="kr">const</span> <span class="nx">network</span> <span class="o">=</span> <span class="nx">Network</span><span class="p">.</span><span class="nx">get</span><span class="p">(</span><span class="s1">'regtest'</span><span class="p">);</span>
@@ -6889,7 +6889,7 @@ curl <span class="nv">$url</span> <span class="se">\</span>
 <span class="kr">const</span> <span class="nx">client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">NodeClient</span><span class="p">(</span><span class="nx">clientOptions</span><span class="p">);</span>
 
 <span class="p">(</span><span class="nx">async</span> <span class="p">()</span> <span class="o">=&gt;</span> <span class="p">{</span>
-  <span class="kr">const</span> <span class="nx">result</span> <span class="o">=</span> <span class="nx">await</span> <span class="nx">client</span><span class="p">.</span><span class="nx">execute</span><span class="p">(</span><span class="s1">'getdnssecproof'</span><span class="p">,</span> <span class="p">[</span> <span class="s1">'domain-name'</span> <span class="p">]);</span>
+  <span class="kr">const</span> <span class="nx">result</span> <span class="o">=</span> <span class="nx">await</span> <span class="nx">client</span><span class="p">.</span><span class="nx">execute</span><span class="p">(</span><span class="s1">'getdnssecproof'</span><span class="p">,</span> <span class="p">[</span> <span class="nx">name</span> <span class="p">]);</span>
   <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="nx">result</span><span class="p">);</span>
 <span class="p">})();</span>
 </code></pre><pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
@@ -6898,12 +6898,12 @@ curl <span class="nv">$url</span> <span class="se">\</span>
 </span></code></pre>
 <p>Query for and build a Handshake DNSSEC ownership proof.
 This is the same proof that is included in a name claim. See
-the <code>sendclaim</code> RPC method to build a transaction that includes
+the <a href="#sendclaim">sendclaim</a> RPC method to build a transaction that includes
 the DNSSEC ownership proof. The <code>estimate</code> param is used to
 validate the proof. If set to <code>false</code>, it will strictly require
 the proof to be valid. If set to <code>true</code>, the proof will be build
 and returned to the caller, even if it is invalid. The default
-<code>value</code> for <code>estimate</code> is <code>false</code>.</p>
+value for <code>estimate</code> is <code>false</code>.</p>
 
 <p>A Handshake DNSSEC ownership proof is a more strict subset of
 a DNSSEC proof. Each parent/child zone must operate through a series
@@ -6922,17 +6922,17 @@ and RSA-1024 is subject to be disabled via soft-fork.</p>
 </thead><tbody>
 <tr>
 <td>name</td>
-<td>Required</td>
+<td></td>
 <td>Domain name</td>
 </tr>
 <tr>
 <td>estimate</td>
-<td>Optional</td>
+<td>false</td>
 <td>No validation when true</td>
 </tr>
 <tr>
 <td>verbose</td>
-<td>Optional</td>
+<td>false</td>
 <td>Returns hex when false</td>
 </tr>
 </tbody></table>

--- a/api-docs/index.html
+++ b/api-docs/index.html
@@ -6897,7 +6897,21 @@ curl <span class="nv">$url</span> <span class="se">\</span>
 </span><span class="p">}</span><span class="w">
 </span></code></pre>
 <p>Query for and build a Handshake DNSSEC ownership proof.
-This is the proof is that is included in a name claim (<code>sendclaim</code>).</p>
+This is the same proof that is included in a name claim. See
+the <code>sendclaim</code> RPC method to build a transaction that includes
+the DNSSEC ownership proof. The <code>estimate</code> param is used to
+validate the proof. If set to <code>false</code>, it will strictly require
+the proof to be valid. If set to <code>true</code>, the proof will be build
+and returned to the caller, even if it is invalid. The default
+<code>value</code> for <code>estimate</code> is <code>false</code>.</p>
+
+<p>A Handshake DNSSEC ownership proof is a more strict subset of
+a DNSSEC proof. Each parent/child zone must operate through a series
+of <code>DS-&gt;DNSKEY</code> relationships, no <code>CNAME</code>s or wildcards are allowed,
+each label separation (<code>.</code>) must behave like a zone cut (with an
+appropriate child zone referral) and weak cryptography is not allowed.
+This means that <code>SHA1</code> digests for <code>DS</code> hashes are not allowed,
+and RSA-1024 is subject to be disabled via soft-fork.</p>
 <h3 id='params-8'>Params</h3>
 <table><thead>
 <tr>

--- a/api-docs/index.html
+++ b/api-docs/index.html
@@ -566,6 +566,9 @@
                     <a href="#sendrawclaim" class="toc-h2 toc-link" data-title="RPC Calls - Names">sendrawclaim</a>
                   </li>
                   <li>
+                    <a href="#getdnssecproof" class="toc-h2 toc-link" data-title="RPC Calls - Names">getdnssecproof</a>
+                  </li>
+                  <li>
                     <a href="#sendrawairdrop" class="toc-h2 toc-link" data-title="RPC Calls - Names">sendrawairdrop</a>
                   </li>
                   <li>
@@ -6867,6 +6870,58 @@ hsd-cli rpc generatetoaddress <span class="nv">$numblocks</span> <span class="nv
 <td>raw serialized hex-string</td>
 </tr>
 </tbody></table>
+<h2 id='getdnssecproof'>getdnssecproof</h2><pre class="highlight shell tab-shell--cli"><code>hsd-rpc getdnssecproof &lt;domain-name&gt;
+</code></pre><pre class="highlight shell tab-shell--curl"><code><span class="nv">domain_name</span><span class="o">=</span>foo.bar
+
+curl <span class="nv">$url</span> <span class="se">\</span>
+  -X POST <span class="se">\</span>
+  --data <span class="s1">'{ "method": "getdnssecproof", "params": ["$domain_name"] }'</span>
+</code></pre><pre class="highlight javascript tab-javascript"><code><span class="kr">const</span> <span class="p">{</span><span class="nx">NodeClient</span><span class="p">}</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'hs-client'</span><span class="p">);</span>
+<span class="kr">const</span> <span class="p">{</span><span class="nx">Network</span><span class="p">}</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'hsd'</span><span class="p">);</span>
+<span class="kr">const</span> <span class="nx">network</span> <span class="o">=</span> <span class="nx">Network</span><span class="p">.</span><span class="nx">get</span><span class="p">(</span><span class="s1">'regtest'</span><span class="p">);</span>
+
+<span class="kr">const</span> <span class="nx">clientOptions</span> <span class="o">=</span> <span class="p">{</span>
+  <span class="na">network</span><span class="p">:</span> <span class="nx">network</span><span class="p">.</span><span class="nx">type</span><span class="p">,</span>
+  <span class="na">port</span><span class="p">:</span> <span class="nx">network</span><span class="p">.</span><span class="nx">rpcPort</span><span class="p">,</span>
+  <span class="na">apiKey</span><span class="p">:</span> <span class="s1">'api-key'</span>
+<span class="p">}</span>
+
+<span class="kr">const</span> <span class="nx">client</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">NodeClient</span><span class="p">(</span><span class="nx">clientOptions</span><span class="p">);</span>
+
+<span class="p">(</span><span class="nx">async</span> <span class="p">()</span> <span class="o">=&gt;</span> <span class="p">{</span>
+  <span class="kr">const</span> <span class="nx">result</span> <span class="o">=</span> <span class="nx">await</span> <span class="nx">client</span><span class="p">.</span><span class="nx">execute</span><span class="p">(</span><span class="s1">'getdnssecproof'</span><span class="p">,</span> <span class="p">[</span> <span class="s1">'domain-name'</span> <span class="p">]);</span>
+  <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="nx">result</span><span class="p">);</span>
+<span class="p">})();</span>
+</code></pre><pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+  </span><span class="s2">"zones"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="err">...</span><span class="p">]</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre>
+<p>Query for and build a Handshake DNSSEC ownership proof.
+This is the proof is that is included in a name claim (<code>sendclaim</code>).</p>
+<h3 id='params-8'>Params</h3>
+<table><thead>
+<tr>
+<th>Name</th>
+<th>Default</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>name</td>
+<td>Required</td>
+<td>Domain name</td>
+</tr>
+<tr>
+<td>estimate</td>
+<td>Optional</td>
+<td>No validation when true</td>
+</tr>
+<tr>
+<td>verbose</td>
+<td>Optional</td>
+<td>Returns hex when false</td>
+</tr>
+</tbody></table>
 <h2 id='sendrawairdrop'>sendrawairdrop</h2><pre class="highlight shell tab-shell--cli"><code>hsd-rpc sendrawairdrop &lt;base64-string&gt;
 </code></pre><pre class="highlight javascript tab-javascript"><code><span class="kr">const</span> <span class="p">{</span><span class="nx">NodeClient</span><span class="p">}</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'hs-client'</span><span class="p">);</span>
 <span class="kr">const</span> <span class="p">{</span><span class="nx">Network</span><span class="p">}</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'hsd'</span><span class="p">);</span>
@@ -6894,7 +6949,7 @@ hsd-cli rpc generatetoaddress <span class="nv">$numblocks</span> <span class="nv
 <p>For details on how to create an airdrop proof, see the
 <a href="https://github.com/handshake-org/hs-airdrop">hs-airdrop</a>
 tool.</p>
-<h3 id='params-8'>Params</h3>
+<h3 id='params-9'>Params</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -6932,7 +6987,7 @@ tool.</p>
 <pre class="highlight json tab-json"><code><span class="err">girnktqvqn</span><span class="w">
 </span></code></pre>
 <p>Grind a rolled-out available name.</p>
-<h3 id='params-9'>Params</h3>
+<h3 id='params-10'>Params</h3>
 <table><thead>
 <tr>
 <th>Name</th>

--- a/guides/events.html
+++ b/guides/events.html
@@ -62,45 +62,45 @@
 <p>To listen for and react to events in hsd, a listener must be added in the runtime script. If you are running a full node (for example) you might already be familiar with <a href="https://github.com/handshake-org/hsd/blob/master/bin/node">the hsd full node launch script</a>, which instantiates a <code>FullNode</code> object, adds a wallet, and begins the connection and synchronization process. The script ends with an <code>async</code> function that actually starts these processes, and this is a good place to add event listeners. <a href="#events-directory">Using the table below</a> you can discover which object needs to be listened <code>on</code> for each event type. Notice that because the wallet is added as a plugin, its object hierarchy path is a little… awkward :-)</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1"></a><span class="co">// Based on https://github.com/handshake-org/hsd/blob/master/bin/node</span></span>
 <span id="cb1-2"><a href="#cb1-2"></a></span>
-<span id="cb1-3"><a href="#cb1-3"></a>(<span class="kw">async</span> () <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb1-4"><a href="#cb1-4"></a>  <span class="cf">await</span> <span class="va">node</span>.<span class="at">ensure</span>()<span class="op">;</span></span>
-<span id="cb1-5"><a href="#cb1-5"></a>  <span class="cf">await</span> <span class="va">node</span>.<span class="at">open</span>()<span class="op">;</span></span>
-<span id="cb1-6"><a href="#cb1-6"></a>  <span class="cf">await</span> <span class="va">node</span>.<span class="at">connect</span>()<span class="op">;</span></span>
-<span id="cb1-7"><a href="#cb1-7"></a>  <span class="va">node</span>.<span class="at">startSync</span>()<span class="op">;</span></span>
+<span id="cb1-3"><a href="#cb1-3"></a>(<span class="kw">async</span> () <span class="kw">=&gt;</span> {</span>
+<span id="cb1-4"><a href="#cb1-4"></a>  <span class="cf">await</span> node<span class="op">.</span><span class="fu">ensure</span>()<span class="op">;</span></span>
+<span id="cb1-5"><a href="#cb1-5"></a>  <span class="cf">await</span> node<span class="op">.</span><span class="fu">open</span>()<span class="op">;</span></span>
+<span id="cb1-6"><a href="#cb1-6"></a>  <span class="cf">await</span> node<span class="op">.</span><span class="fu">connect</span>()<span class="op">;</span></span>
+<span id="cb1-7"><a href="#cb1-7"></a>  node<span class="op">.</span><span class="fu">startSync</span>()<span class="op">;</span></span>
 <span id="cb1-8"><a href="#cb1-8"></a></span>
 <span id="cb1-9"><a href="#cb1-9"></a>  <span class="co">// add event listeners after everything is open, connected, and started</span></span>
 <span id="cb1-10"><a href="#cb1-10"></a></span>
 <span id="cb1-11"><a href="#cb1-11"></a>  <span class="co">// NODE</span></span>
-<span id="cb1-12"><a href="#cb1-12"></a>  <span class="va">node</span>.<span class="at">on</span>(<span class="st">&#39;tx&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb1-13"><a href="#cb1-13"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- node tx -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-14"><a href="#cb1-14"></a>  <span class="op">}</span>)<span class="op">;</span></span>
+<span id="cb1-12"><a href="#cb1-12"></a>  node<span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;tx&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
+<span id="cb1-13"><a href="#cb1-13"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- node tx -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-14"><a href="#cb1-14"></a>  })<span class="op">;</span></span>
 <span id="cb1-15"><a href="#cb1-15"></a>  </span>
-<span id="cb1-16"><a href="#cb1-16"></a>  <span class="va">node</span>.<span class="at">on</span>(<span class="st">&#39;block&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb1-17"><a href="#cb1-17"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- node block -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-18"><a href="#cb1-18"></a>  <span class="op">}</span>)<span class="op">;</span></span>
+<span id="cb1-16"><a href="#cb1-16"></a>  node<span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;block&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
+<span id="cb1-17"><a href="#cb1-17"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- node block -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-18"><a href="#cb1-18"></a>  })<span class="op">;</span></span>
 <span id="cb1-19"><a href="#cb1-19"></a></span>
 <span id="cb1-20"><a href="#cb1-20"></a>  <span class="co">// MEMPOOL</span></span>
-<span id="cb1-21"><a href="#cb1-21"></a>  <span class="va">node</span>.<span class="va">mempool</span>.<span class="at">on</span>(<span class="st">&#39;confirmed&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb1-22"><a href="#cb1-22"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- mempool confirmed -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-23"><a href="#cb1-23"></a>  <span class="op">}</span>)<span class="op">;</span></span>
+<span id="cb1-21"><a href="#cb1-21"></a>  node<span class="op">.</span><span class="at">mempool</span><span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;confirmed&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
+<span id="cb1-22"><a href="#cb1-22"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- mempool confirmed -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-23"><a href="#cb1-23"></a>  })<span class="op">;</span></span>
 <span id="cb1-24"><a href="#cb1-24"></a></span>
 <span id="cb1-25"><a href="#cb1-25"></a>  <span class="co">// WALLET</span></span>
-<span id="cb1-26"><a href="#cb1-26"></a>  <span class="va">node</span>.<span class="va">plugins</span>.<span class="va">walletdb</span>.<span class="va">wdb</span>.<span class="at">on</span>(<span class="st">&#39;balance&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb1-27"><a href="#cb1-27"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- wallet balance -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-28"><a href="#cb1-28"></a>  <span class="op">}</span>)<span class="op">;</span></span>
+<span id="cb1-26"><a href="#cb1-26"></a>  node<span class="op">.</span><span class="at">plugins</span><span class="op">.</span><span class="at">walletdb</span><span class="op">.</span><span class="at">wdb</span><span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;balance&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
+<span id="cb1-27"><a href="#cb1-27"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- wallet balance -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-28"><a href="#cb1-28"></a>  })<span class="op">;</span></span>
 <span id="cb1-29"><a href="#cb1-29"></a></span>
-<span id="cb1-30"><a href="#cb1-30"></a>  <span class="va">node</span>.<span class="va">plugins</span>.<span class="va">walletdb</span>.<span class="va">wdb</span>.<span class="at">on</span>(<span class="st">&#39;confirmed&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb1-31"><a href="#cb1-31"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- wallet confirmed -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-32"><a href="#cb1-32"></a>  <span class="op">}</span>)<span class="op">;</span></span>
+<span id="cb1-30"><a href="#cb1-30"></a>  node<span class="op">.</span><span class="at">plugins</span><span class="op">.</span><span class="at">walletdb</span><span class="op">.</span><span class="at">wdb</span><span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;confirmed&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
+<span id="cb1-31"><a href="#cb1-31"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- wallet confirmed -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-32"><a href="#cb1-32"></a>  })<span class="op">;</span></span>
 <span id="cb1-33"><a href="#cb1-33"></a></span>
-<span id="cb1-34"><a href="#cb1-34"></a>  <span class="va">node</span>.<span class="va">plugins</span>.<span class="va">walletdb</span>.<span class="va">wdb</span>.<span class="at">on</span>(<span class="st">&#39;address&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb1-35"><a href="#cb1-35"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- wallet address -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-36"><a href="#cb1-36"></a>  <span class="op">}</span>)<span class="op">;</span></span>
+<span id="cb1-34"><a href="#cb1-34"></a>  node<span class="op">.</span><span class="at">plugins</span><span class="op">.</span><span class="at">walletdb</span><span class="op">.</span><span class="at">wdb</span><span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;address&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
+<span id="cb1-35"><a href="#cb1-35"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- wallet address -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-36"><a href="#cb1-36"></a>  })<span class="op">;</span></span>
 <span id="cb1-37"><a href="#cb1-37"></a></span>
-<span id="cb1-38"><a href="#cb1-38"></a><span class="op">}</span>)().<span class="at">catch</span>((err) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb1-39"><a href="#cb1-39"></a>  <span class="va">console</span>.<span class="at">error</span>(<span class="va">err</span>.<span class="at">stack</span>)<span class="op">;</span></span>
-<span id="cb1-40"><a href="#cb1-40"></a>  <span class="va">process</span>.<span class="at">exit</span>(<span class="dv">1</span>)<span class="op">;</span></span>
-<span id="cb1-41"><a href="#cb1-41"></a><span class="op">}</span>)<span class="op">;</span></span></code></pre></div>
+<span id="cb1-38"><a href="#cb1-38"></a>})()<span class="op">.</span><span class="fu">catch</span>((err) <span class="kw">=&gt;</span> {</span>
+<span id="cb1-39"><a href="#cb1-39"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">error</span>(err<span class="op">.</span><span class="at">stack</span>)<span class="op">;</span></span>
+<span id="cb1-40"><a href="#cb1-40"></a>  <span class="bu">process</span><span class="op">.</span><span class="fu">exit</span>(<span class="dv">1</span>)<span class="op">;</span></span>
+<span id="cb1-41"><a href="#cb1-41"></a>})<span class="op">;</span></span></code></pre></div>
 <h2 id="events-directory">Events Directory</h2>
 <p>This list is comprehensive for all Handshake transaction, wallet, and blockchain activity. Events regarding errors, socket connections and peer connections have been omitted for clarity. Notice that certain methods emit the same events but with different return objects, and not all re-emitters return everything they receive.</p>
 <table>
@@ -277,66 +277,66 @@
 <p>To make a socket connection to hsd, you need to run a websocket client. Luckily the bcoin and hsd developers have developed <a href="https://github.com/bcoin-org/bsock">bsock</a>, a minimal websocket-only implementation of the socket.io protocol. By default, bsock listens on <code>localhost</code>, and you only need to pass it a port number to connect to one of the hsd servers. The example below illustrates how to establish the socket connection, authenticate with your user-defined <a href="https://handshake-org.github.io/api-docs/#authentication">API key</a> and then send and receive events! <a href="#socket-events-directory">See the tables below for a complete list of calls and events available in hsd.</a></p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1"></a><span class="co">// bsock-example.js</span></span>
 <span id="cb2-2"><a href="#cb2-2"></a></span>
-<span id="cb2-3"><a href="#cb2-3"></a><span class="kw">const</span> bsock <span class="op">=</span> <span class="at">require</span>(<span class="st">&#39;bsock&#39;</span>)<span class="op">;</span></span>
-<span id="cb2-4"><a href="#cb2-4"></a><span class="kw">const</span> <span class="op">{</span>Network<span class="op">,</span> ChainEntry<span class="op">}</span> <span class="op">=</span> <span class="at">require</span>(<span class="st">&#39;hsd&#39;</span>)<span class="op">;</span></span>
-<span id="cb2-5"><a href="#cb2-5"></a><span class="kw">const</span> network <span class="op">=</span> <span class="va">Network</span>.<span class="at">get</span>(<span class="st">&#39;regtest&#39;</span>)<span class="op">;</span></span>
+<span id="cb2-3"><a href="#cb2-3"></a><span class="kw">const</span> bsock <span class="op">=</span> <span class="pp">require</span>(<span class="st">&#39;bsock&#39;</span>)<span class="op">;</span></span>
+<span id="cb2-4"><a href="#cb2-4"></a><span class="kw">const</span> {Network<span class="op">,</span> ChainEntry} <span class="op">=</span> <span class="pp">require</span>(<span class="st">&#39;hsd&#39;</span>)<span class="op">;</span></span>
+<span id="cb2-5"><a href="#cb2-5"></a><span class="kw">const</span> network <span class="op">=</span> Network<span class="op">.</span><span class="fu">get</span>(<span class="st">&#39;regtest&#39;</span>)<span class="op">;</span></span>
 <span id="cb2-6"><a href="#cb2-6"></a><span class="kw">const</span> apiKey <span class="op">=</span> <span class="st">&#39;api-key&#39;</span><span class="op">;</span></span>
 <span id="cb2-7"><a href="#cb2-7"></a></span>
-<span id="cb2-8"><a href="#cb2-8"></a>nodeSocket <span class="op">=</span> <span class="va">bsock</span>.<span class="at">connect</span>(<span class="va">network</span>.<span class="at">rpcPort</span>)<span class="op">;</span></span>
-<span id="cb2-9"><a href="#cb2-9"></a>walletSocket <span class="op">=</span> <span class="va">bsock</span>.<span class="at">connect</span>(<span class="va">network</span>.<span class="at">walletPort</span>)<span class="op">;</span></span>
+<span id="cb2-8"><a href="#cb2-8"></a>nodeSocket <span class="op">=</span> bsock<span class="op">.</span><span class="fu">connect</span>(network<span class="op">.</span><span class="at">rpcPort</span>)<span class="op">;</span></span>
+<span id="cb2-9"><a href="#cb2-9"></a>walletSocket <span class="op">=</span> bsock<span class="op">.</span><span class="fu">connect</span>(network<span class="op">.</span><span class="at">walletPort</span>)<span class="op">;</span></span>
 <span id="cb2-10"><a href="#cb2-10"></a></span>
-<span id="cb2-11"><a href="#cb2-11"></a><span class="va">nodeSocket</span>.<span class="at">on</span>(<span class="st">&#39;connect&#39;</span><span class="op">,</span> <span class="kw">async</span> (e) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb2-12"><a href="#cb2-12"></a>  <span class="cf">try</span> <span class="op">{</span></span>
-<span id="cb2-13"><a href="#cb2-13"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Connect event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
+<span id="cb2-11"><a href="#cb2-11"></a>nodeSocket<span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;connect&#39;</span><span class="op">,</span> <span class="kw">async</span> (e) <span class="kw">=&gt;</span> {</span>
+<span id="cb2-12"><a href="#cb2-12"></a>  <span class="cf">try</span> {</span>
+<span id="cb2-13"><a href="#cb2-13"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Connect event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
 <span id="cb2-14"><a href="#cb2-14"></a></span>
 <span id="cb2-15"><a href="#cb2-15"></a>    <span class="co">// `auth` must be called before any other actions</span></span>
-<span id="cb2-16"><a href="#cb2-16"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Attempting auth:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> <span class="va">nodeSocket</span>.<span class="at">call</span>(<span class="st">&#39;auth&#39;</span><span class="op">,</span> apiKey))<span class="op">;</span></span>
+<span id="cb2-16"><a href="#cb2-16"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Attempting auth:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> nodeSocket<span class="op">.</span><span class="fu">call</span>(<span class="st">&#39;auth&#39;</span><span class="op">,</span> apiKey))<span class="op">;</span></span>
 <span id="cb2-17"><a href="#cb2-17"></a></span>
 <span id="cb2-18"><a href="#cb2-18"></a>    <span class="co">// `watch chain` subscirbes us to chain events like `block`</span></span>
-<span id="cb2-19"><a href="#cb2-19"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Attempting watch chain:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> <span class="va">nodeSocket</span>.<span class="at">call</span>(<span class="st">&#39;watch chain&#39;</span>))<span class="op">;</span></span>
+<span id="cb2-19"><a href="#cb2-19"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Attempting watch chain:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> nodeSocket<span class="op">.</span><span class="fu">call</span>(<span class="st">&#39;watch chain&#39;</span>))<span class="op">;</span></span>
 <span id="cb2-20"><a href="#cb2-20"></a></span>
 <span id="cb2-21"><a href="#cb2-21"></a>    <span class="co">// Some calls simply request information from the server like an http request</span></span>
-<span id="cb2-22"><a href="#cb2-22"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Attempting get tip:&#39;</span>)<span class="op">;</span></span>
-<span id="cb2-23"><a href="#cb2-23"></a>    <span class="kw">const</span> tip <span class="op">=</span> <span class="cf">await</span> <span class="va">nodeSocket</span>.<span class="at">call</span>(<span class="st">&#39;get tip&#39;</span>)<span class="op">;</span></span>
-<span id="cb2-24"><a href="#cb2-24"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="va">ChainEntry</span>.<span class="at">from</span>(tip))<span class="op">;</span></span>
+<span id="cb2-22"><a href="#cb2-22"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Attempting get tip:&#39;</span>)<span class="op">;</span></span>
+<span id="cb2-23"><a href="#cb2-23"></a>    <span class="kw">const</span> tip <span class="op">=</span> <span class="cf">await</span> nodeSocket<span class="op">.</span><span class="fu">call</span>(<span class="st">&#39;get tip&#39;</span>)<span class="op">;</span></span>
+<span id="cb2-24"><a href="#cb2-24"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(ChainEntry<span class="op">.</span><span class="fu">from</span>(tip))<span class="op">;</span></span>
 <span id="cb2-25"><a href="#cb2-25"></a></span>
-<span id="cb2-26"><a href="#cb2-26"></a>  <span class="op">}</span> <span class="cf">catch</span> (e) <span class="op">{</span></span>
-<span id="cb2-27"><a href="#cb2-27"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Connection Error:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
-<span id="cb2-28"><a href="#cb2-28"></a>  <span class="op">}</span> </span>
-<span id="cb2-29"><a href="#cb2-29"></a><span class="op">}</span>)<span class="op">;</span></span>
+<span id="cb2-26"><a href="#cb2-26"></a>  } <span class="cf">catch</span> (e) {</span>
+<span id="cb2-27"><a href="#cb2-27"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Connection Error:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
+<span id="cb2-28"><a href="#cb2-28"></a>  } </span>
+<span id="cb2-29"><a href="#cb2-29"></a>})<span class="op">;</span></span>
 <span id="cb2-30"><a href="#cb2-30"></a></span>
 <span id="cb2-31"><a href="#cb2-31"></a><span class="co">// listen for new blocks</span></span>
-<span id="cb2-32"><a href="#cb2-32"></a><span class="va">nodeSocket</span>.<span class="at">bind</span>(<span class="st">&#39;chain connect&#39;</span><span class="op">,</span> (raw<span class="op">,</span> txs) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb2-33"><a href="#cb2-33"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Chain Connect Event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="va">ChainEntry</span>.<span class="at">fromRaw</span>(raw))<span class="op">;</span></span>
-<span id="cb2-34"><a href="#cb2-34"></a><span class="op">}</span>)<span class="op">;</span></span>
+<span id="cb2-32"><a href="#cb2-32"></a>nodeSocket<span class="op">.</span><span class="fu">bind</span>(<span class="st">&#39;chain connect&#39;</span><span class="op">,</span> (raw<span class="op">,</span> txs) <span class="kw">=&gt;</span> {</span>
+<span id="cb2-33"><a href="#cb2-33"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Chain Connect Event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> ChainEntry<span class="op">.</span><span class="fu">fromRaw</span>(raw))<span class="op">;</span></span>
+<span id="cb2-34"><a href="#cb2-34"></a>})<span class="op">;</span></span>
 <span id="cb2-35"><a href="#cb2-35"></a></span>
-<span id="cb2-36"><a href="#cb2-36"></a><span class="va">walletSocket</span>.<span class="at">on</span>(<span class="st">&#39;connect&#39;</span><span class="op">,</span> <span class="kw">async</span> (e) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb2-37"><a href="#cb2-37"></a>  <span class="cf">try</span> <span class="op">{</span></span>
-<span id="cb2-38"><a href="#cb2-38"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Connect event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
+<span id="cb2-36"><a href="#cb2-36"></a>walletSocket<span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;connect&#39;</span><span class="op">,</span> <span class="kw">async</span> (e) <span class="kw">=&gt;</span> {</span>
+<span id="cb2-37"><a href="#cb2-37"></a>  <span class="cf">try</span> {</span>
+<span id="cb2-38"><a href="#cb2-38"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Connect event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
 <span id="cb2-39"><a href="#cb2-39"></a></span>
 <span id="cb2-40"><a href="#cb2-40"></a>    <span class="co">// `auth` is required before proceeding</span></span>
-<span id="cb2-41"><a href="#cb2-41"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Attempting auth:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> <span class="va">walletSocket</span>.<span class="at">call</span>(<span class="st">&#39;auth&#39;</span><span class="op">,</span> apiKey))<span class="op">;</span></span>
+<span id="cb2-41"><a href="#cb2-41"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Attempting auth:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> walletSocket<span class="op">.</span><span class="fu">call</span>(<span class="st">&#39;auth&#39;</span><span class="op">,</span> apiKey))<span class="op">;</span></span>
 <span id="cb2-42"><a href="#cb2-42"></a></span>
 <span id="cb2-43"><a href="#cb2-43"></a>    <span class="co">// here we join all wallets, but we could also just join `primary` or any other wallet</span></span>
-<span id="cb2-44"><a href="#cb2-44"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Attempting join *:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> <span class="va">walletSocket</span>.<span class="at">call</span>(<span class="st">&#39;join&#39;</span><span class="op">,</span> <span class="st">&#39;*&#39;</span>))<span class="op">;</span></span>
+<span id="cb2-44"><a href="#cb2-44"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Attempting join *:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> walletSocket<span class="op">.</span><span class="fu">call</span>(<span class="st">&#39;join&#39;</span><span class="op">,</span> <span class="st">&#39;*&#39;</span>))<span class="op">;</span></span>
 <span id="cb2-45"><a href="#cb2-45"></a></span>
-<span id="cb2-46"><a href="#cb2-46"></a>  <span class="op">}</span> <span class="cf">catch</span> (e) <span class="op">{</span></span>
-<span id="cb2-47"><a href="#cb2-47"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Connection Error:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
-<span id="cb2-48"><a href="#cb2-48"></a>  <span class="op">}</span> </span>
-<span id="cb2-49"><a href="#cb2-49"></a><span class="op">}</span>)<span class="op">;</span></span>
+<span id="cb2-46"><a href="#cb2-46"></a>  } <span class="cf">catch</span> (e) {</span>
+<span id="cb2-47"><a href="#cb2-47"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Connection Error:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
+<span id="cb2-48"><a href="#cb2-48"></a>  } </span>
+<span id="cb2-49"><a href="#cb2-49"></a>})<span class="op">;</span></span>
 <span id="cb2-50"><a href="#cb2-50"></a></span>
 <span id="cb2-51"><a href="#cb2-51"></a><span class="co">// listen for new wallet transactions</span></span>
-<span id="cb2-52"><a href="#cb2-52"></a><span class="va">walletSocket</span>.<span class="at">bind</span>(<span class="st">&#39;tx&#39;</span><span class="op">,</span> (wallet<span class="op">,</span> tx) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb2-53"><a href="#cb2-53"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - TX Event -- wallet:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> wallet)<span class="op">;</span></span>
-<span id="cb2-54"><a href="#cb2-54"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - TX Event -- tx:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> tx)<span class="op">;</span></span>
-<span id="cb2-55"><a href="#cb2-55"></a><span class="op">}</span>)<span class="op">;</span></span>
+<span id="cb2-52"><a href="#cb2-52"></a>walletSocket<span class="op">.</span><span class="fu">bind</span>(<span class="st">&#39;tx&#39;</span><span class="op">,</span> (wallet<span class="op">,</span> tx) <span class="kw">=&gt;</span> {</span>
+<span id="cb2-53"><a href="#cb2-53"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - TX Event -- wallet:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> wallet)<span class="op">;</span></span>
+<span id="cb2-54"><a href="#cb2-54"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - TX Event -- tx:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> tx)<span class="op">;</span></span>
+<span id="cb2-55"><a href="#cb2-55"></a>})<span class="op">;</span></span>
 <span id="cb2-56"><a href="#cb2-56"></a></span>
 <span id="cb2-57"><a href="#cb2-57"></a><span class="co">// listen for new address events</span></span>
 <span id="cb2-58"><a href="#cb2-58"></a><span class="co">// (only fired when current account address receives a transaction)</span></span>
-<span id="cb2-59"><a href="#cb2-59"></a><span class="va">walletSocket</span>.<span class="at">bind</span>(<span class="st">&#39;address&#39;</span><span class="op">,</span> (wallet<span class="op">,</span> json) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb2-60"><a href="#cb2-60"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Address Event -- wallet:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> wallet)<span class="op">;</span></span>
-<span id="cb2-61"><a href="#cb2-61"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Address Event -- json:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> json)<span class="op">;</span></span>
-<span id="cb2-62"><a href="#cb2-62"></a><span class="op">}</span>)<span class="op">;</span></span></code></pre></div>
+<span id="cb2-59"><a href="#cb2-59"></a>walletSocket<span class="op">.</span><span class="fu">bind</span>(<span class="st">&#39;address&#39;</span><span class="op">,</span> (wallet<span class="op">,</span> json) <span class="kw">=&gt;</span> {</span>
+<span id="cb2-60"><a href="#cb2-60"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Address Event -- wallet:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> wallet)<span class="op">;</span></span>
+<span id="cb2-61"><a href="#cb2-61"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Address Event -- json:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> json)<span class="op">;</span></span>
+<span id="cb2-62"><a href="#cb2-62"></a>})<span class="op">;</span></span></code></pre></div>
 <p>To see this script in action, first start hsd however you usually do:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1"></a><span class="ex">hsd</span> --daemon --network=regtest</span></code></pre></div>
 <p>Run the script (this is where the event output will be printed):</p>
@@ -347,30 +347,30 @@
 <p><code>bsock</code> is a great low-level library for dealing with sockets, but we also have <a href="https://github.com/handshake-org/hs-client">hs-client</a> which simplifies both socket and regular http connections. A simple one-line command in the terminal can listen to all wallet events and print all the returned data:</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1"></a><span class="ex">hsw-cli</span> listen</span></code></pre></div>
 <p><code>hs-client</code> can also be used in a script to listen for events. If you’re already familiar with the <a href="https://handshake-org.github.io/api-docs">hsd-cli API</a> this will look very familiar. Here’s part of the script above re-written using <code>hs-client</code> instead of <code>bsock</code>:</p>
-<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1"></a><span class="kw">const</span> <span class="op">{</span>NodeClient<span class="op">}</span> <span class="op">=</span> <span class="at">require</span>(<span class="st">&#39;hs-client&#39;</span>)<span class="op">;</span></span>
-<span id="cb7-2"><a href="#cb7-2"></a><span class="kw">const</span> <span class="op">{</span>Network<span class="op">,</span> ChainEntry<span class="op">}</span> <span class="op">=</span> <span class="at">require</span>(<span class="st">&#39;hsd&#39;</span>)<span class="op">;</span></span>
-<span id="cb7-3"><a href="#cb7-3"></a><span class="kw">const</span> network <span class="op">=</span> <span class="va">Network</span>.<span class="at">get</span>(<span class="st">&#39;regtest&#39;</span>)<span class="op">;</span></span>
+<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1"></a><span class="kw">const</span> {NodeClient} <span class="op">=</span> <span class="pp">require</span>(<span class="st">&#39;hs-client&#39;</span>)<span class="op">;</span></span>
+<span id="cb7-2"><a href="#cb7-2"></a><span class="kw">const</span> {Network<span class="op">,</span> ChainEntry} <span class="op">=</span> <span class="pp">require</span>(<span class="st">&#39;hsd&#39;</span>)<span class="op">;</span></span>
+<span id="cb7-3"><a href="#cb7-3"></a><span class="kw">const</span> network <span class="op">=</span> Network<span class="op">.</span><span class="fu">get</span>(<span class="st">&#39;regtest&#39;</span>)<span class="op">;</span></span>
 <span id="cb7-4"><a href="#cb7-4"></a></span>
-<span id="cb7-5"><a href="#cb7-5"></a><span class="kw">const</span> clientOptions <span class="op">=</span> <span class="op">{</span></span>
-<span id="cb7-6"><a href="#cb7-6"></a>  <span class="dt">network</span><span class="op">:</span> <span class="va">network</span>.<span class="at">type</span><span class="op">,</span></span>
-<span id="cb7-7"><a href="#cb7-7"></a>  <span class="dt">port</span><span class="op">:</span> <span class="va">network</span>.<span class="at">rpcPort</span><span class="op">,</span></span>
+<span id="cb7-5"><a href="#cb7-5"></a><span class="kw">const</span> clientOptions <span class="op">=</span> {</span>
+<span id="cb7-6"><a href="#cb7-6"></a>  <span class="dt">network</span><span class="op">:</span> network<span class="op">.</span><span class="at">type</span><span class="op">,</span></span>
+<span id="cb7-7"><a href="#cb7-7"></a>  <span class="dt">port</span><span class="op">:</span> network<span class="op">.</span><span class="at">rpcPort</span><span class="op">,</span></span>
 <span id="cb7-8"><a href="#cb7-8"></a>  <span class="dt">apiKey</span><span class="op">:</span> <span class="st">&#39;api-key&#39;</span></span>
-<span id="cb7-9"><a href="#cb7-9"></a><span class="op">}</span></span>
-<span id="cb7-10"><a href="#cb7-10"></a><span class="kw">const</span> client <span class="op">=</span> <span class="kw">new</span> <span class="at">NodeClient</span>(clientOptions)<span class="op">;</span></span>
+<span id="cb7-9"><a href="#cb7-9"></a>}</span>
+<span id="cb7-10"><a href="#cb7-10"></a><span class="kw">const</span> client <span class="op">=</span> <span class="kw">new</span> NodeClient(clientOptions)<span class="op">;</span></span>
 <span id="cb7-11"><a href="#cb7-11"></a></span>
-<span id="cb7-12"><a href="#cb7-12"></a>(<span class="kw">async</span> () <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb7-12"><a href="#cb7-12"></a>(<span class="kw">async</span> () <span class="kw">=&gt;</span> {</span>
 <span id="cb7-13"><a href="#cb7-13"></a>  <span class="co">// bclient handles the connection, the auth, and the channel subscriptions</span></span>
-<span id="cb7-14"><a href="#cb7-14"></a>  <span class="cf">await</span> <span class="va">client</span>.<span class="at">open</span>()<span class="op">;</span></span>
+<span id="cb7-14"><a href="#cb7-14"></a>  <span class="cf">await</span> client<span class="op">.</span><span class="fu">open</span>()<span class="op">;</span></span>
 <span id="cb7-15"><a href="#cb7-15"></a></span>
 <span id="cb7-16"><a href="#cb7-16"></a>  <span class="co">// use socket connection to request data</span></span>
-<span id="cb7-17"><a href="#cb7-17"></a>  <span class="kw">const</span> tip <span class="op">=</span> <span class="cf">await</span> <span class="va">client</span>.<span class="at">getTip</span>()<span class="op">;</span></span>
-<span id="cb7-18"><a href="#cb7-18"></a>  <span class="va">console</span>.<span class="at">log</span>(tip)<span class="op">;</span></span>
-<span id="cb7-19"><a href="#cb7-19"></a><span class="op">}</span>)()<span class="op">;</span></span>
+<span id="cb7-17"><a href="#cb7-17"></a>  <span class="kw">const</span> tip <span class="op">=</span> <span class="cf">await</span> client<span class="op">.</span><span class="fu">getTip</span>()<span class="op">;</span></span>
+<span id="cb7-18"><a href="#cb7-18"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(tip)<span class="op">;</span></span>
+<span id="cb7-19"><a href="#cb7-19"></a>})()<span class="op">;</span></span>
 <span id="cb7-20"><a href="#cb7-20"></a></span>
 <span id="cb7-21"><a href="#cb7-21"></a><span class="co">// listen for new blocks</span></span>
-<span id="cb7-22"><a href="#cb7-22"></a><span class="va">client</span>.<span class="at">bind</span>(<span class="st">&#39;chain connect&#39;</span><span class="op">,</span> (raw) <span class="kw">=&gt;</span> <span class="op">{</span></span>
-<span id="cb7-23"><a href="#cb7-23"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Chain Connect Event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="va">ChainEntry</span>.<span class="at">fromRaw</span>(raw))<span class="op">;</span></span>
-<span id="cb7-24"><a href="#cb7-24"></a><span class="op">}</span>)<span class="op">;</span></span></code></pre></div>
+<span id="cb7-22"><a href="#cb7-22"></a>client<span class="op">.</span><span class="fu">bind</span>(<span class="st">&#39;chain connect&#39;</span><span class="op">,</span> (raw) <span class="kw">=&gt;</span> {</span>
+<span id="cb7-23"><a href="#cb7-23"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Chain Connect Event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> ChainEntry<span class="op">.</span><span class="fu">fromRaw</span>(raw))<span class="op">;</span></span>
+<span id="cb7-24"><a href="#cb7-24"></a>})<span class="op">;</span></span></code></pre></div>
 <h2 id="socket-events-directory">Socket Events Directory</h2>
 <h3 id="wallet">Wallet</h3>
 <p>All wallet events are emitted by a <code>WalletDB</code> object, which may have been triggered by its parent <code>TXDB</code> or <code>Wallet</code>. The socket emits the event along with the wallet ID, and the same “Returns” as listed above.</p>

--- a/src/api-docs/source/includes/_node_rpc_names.md
+++ b/src/api-docs/source/includes/_node_rpc_names.md
@@ -503,7 +503,7 @@ hsd-rpc getdnssecproof "$name"
 ```shell--curl
 curl $url \
     -X POST \
-    --data "{\"method\":\"getdnssecproof\",\"params\":["\"$name\""]}"
+    --data '{"method":"getdnssecproof","params":["'$name'"]}'
 ```
 
 ```javascript
@@ -536,7 +536,7 @@ This is the same proof that is included in a name claim. See
 the [sendclaim](#sendclaim) RPC method to build a transaction that includes
 the DNSSEC ownership proof. The `estimate` param is used to
 validate the proof. If set to `false`, it will strictly require
-the proof to be valid. If set to `true`, the proof will be build
+the proof to be valid. If set to `true`, the proof will be built
 and returned to the caller, even if it is invalid. The default
 value for `estimate` is `false`.
 
@@ -545,7 +545,7 @@ a DNSSEC proof. Each parent/child zone must operate through a series
 of `DS->DNSKEY` relationships, no `CNAME`s or wildcards are allowed,
 each label separation (`.`) must behave like a zone cut (with an
 appropriate child zone referral) and weak cryptography is not allowed.
-This means that `SHA1` digests for `DS` hashes are not allowed,
+This means that SHA1 digests for `DS` hashes are not allowed,
 and RSA-1024 is subject to be disabled via soft-fork.
 
 ### Params
@@ -553,7 +553,7 @@ Name | Default | Description
 --------- | --------- | --------- |
 name | | Domain name
 estimate | false | No validation when true
-verbose | false | Returns hex when false
+verbose | true | Returns hex when false
 
 ## sendrawairdrop
 

--- a/src/api-docs/source/includes/_node_rpc_names.md
+++ b/src/api-docs/source/includes/_node_rpc_names.md
@@ -526,7 +526,21 @@ const client = new NodeClient(clientOptions);
 ```
 
 Query for and build a Handshake DNSSEC ownership proof.
-This is the proof that is included in a name claim (`sendclaim`).
+This is the same proof that is included in a name claim. See
+the `sendclaim` RPC method to build a transaction that includes
+the DNSSEC ownership proof. The `estimate` param is used to
+validate the proof. If set to `false`, it will strictly require
+the proof to be valid. If set to `true`, the proof will be build
+and returned to the caller, even if it is invalid. The default
+`value` for `estimate` is `false`.
+
+A Handshake DNSSEC ownership proof is a more strict subset of
+a DNSSEC proof. Each parent/child zone must operate through a series
+of `DS->DNSKEY` relationships, no `CNAME`s or wildcards are allowed,
+each label separation (`.`) must behave like a zone cut (with an
+appropriate child zone referral) and weak cryptography is not allowed.
+This means that `SHA1` digests for `DS` hashes are not allowed,
+and RSA-1024 is subject to be disabled via soft-fork.
 
 ### Params
 Name | Default | Description

--- a/src/api-docs/source/includes/_node_rpc_names.md
+++ b/src/api-docs/source/includes/_node_rpc_names.md
@@ -486,6 +486,55 @@ Name | Default |  Description
 --------- | --------- | --------- | -----------
 claim | Required | raw serialized hex-string
 
+## getdnssecproof
+
+```shell--cli
+hsd-rpc getdnssecproof <domain-name>
+```
+
+```shell--curl
+domain_name=foo.bar
+
+curl $url \
+  -X POST \
+  --data '{ "method": "getdnssecproof", "params": ["$domain_name"] }'
+```
+
+```javascript
+const {NodeClient} = require('hs-client');
+const {Network} = require('hsd');
+const network = Network.get('regtest');
+
+const clientOptions = {
+  network: network.type,
+  port: network.rpcPort,
+  apiKey: 'api-key'
+}
+
+const client = new NodeClient(clientOptions);
+
+(async () => {
+  const result = await client.execute('getdnssecproof', [ 'domain-name' ]);
+  console.log(result);
+})();
+```
+
+```json
+{
+  "zones": [...]
+}
+```
+
+Query for and build a Handshake DNSSEC ownership proof.
+This is the proof that is included in a name claim (`sendclaim`).
+
+### Params
+Name | Default | Description
+--------- | --------- | --------- |
+name | Required | Domain name
+estimate | Optional | No validation when true
+verbose | Optional | Returns hex when false
+
 ## sendrawairdrop
 
 ```shell--cli

--- a/src/api-docs/source/includes/_node_rpc_names.md
+++ b/src/api-docs/source/includes/_node_rpc_names.md
@@ -488,16 +488,22 @@ claim | Required | raw serialized hex-string
 
 ## getdnssecproof
 
+```javascript
+let name;
+```
+
+```shell--vars
+name='foo.bar';
+```
+
 ```shell--cli
-hsd-rpc getdnssecproof <domain-name>
+hsd-rpc getdnssecproof "$name"
 ```
 
 ```shell--curl
-domain_name=foo.bar
-
 curl $url \
-  -X POST \
-  --data '{ "method": "getdnssecproof", "params": ["$domain_name"] }'
+    -X POST \
+    --data "{\"method\":\"getdnssecproof\",\"params\":["\"$name\""]}"
 ```
 
 ```javascript
@@ -514,7 +520,7 @@ const clientOptions = {
 const client = new NodeClient(clientOptions);
 
 (async () => {
-  const result = await client.execute('getdnssecproof', [ 'domain-name' ]);
+  const result = await client.execute('getdnssecproof', [ name ]);
   console.log(result);
 })();
 ```
@@ -527,12 +533,12 @@ const client = new NodeClient(clientOptions);
 
 Query for and build a Handshake DNSSEC ownership proof.
 This is the same proof that is included in a name claim. See
-the `sendclaim` RPC method to build a transaction that includes
+the [sendclaim](#sendclaim) RPC method to build a transaction that includes
 the DNSSEC ownership proof. The `estimate` param is used to
 validate the proof. If set to `false`, it will strictly require
 the proof to be valid. If set to `true`, the proof will be build
 and returned to the caller, even if it is invalid. The default
-`value` for `estimate` is `false`.
+value for `estimate` is `false`.
 
 A Handshake DNSSEC ownership proof is a more strict subset of
 a DNSSEC proof. Each parent/child zone must operate through a series
@@ -545,9 +551,9 @@ and RSA-1024 is subject to be disabled via soft-fork.
 ### Params
 Name | Default | Description
 --------- | --------- | --------- |
-name | Required | Domain name
-estimate | Optional | No validation when true
-verbose | Optional | Returns hex when false
+name | | Domain name
+estimate | false | No validation when true
+verbose | false | Returns hex when false
 
 ## sendrawairdrop
 


### PR DESCRIPTION
This adds docs for the node RPC method `getdnssecproof` that is implemented here: https://github.com/handshake-org/hsd/pull/261

The logic for this is located here: https://github.com/chjj/bns/blob/master/lib/ownership.js#L735