### PR TITLE
readme: quickfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,16 @@ Build jsdoc:
 To view the site locally, run a simple http server from the project's
 root directory. 
 
-Python:
+Python2:
 
 ```bash
 $ python -m SimpleHTTPServer 8080
+```
+
+Python3:
+
+```bash
+$ python -m http.server 8080
 ```
 
 Ruby:


### PR DESCRIPTION
Now that `python2` is no longer being maintained, this PR adds to the `README` how to serve the docs using `python3`. It makes no assumptions about what the python executable is called and assumes the user will be able to figure out which version they are running.