### PR TITLE
api-docs: expand introduction and use explicit URLs in examples

### DIFF
--- a/guides/events.html
+++ b/guides/events.html
@@ -62,45 +62,45 @@
 <p>To listen for and react to events in hsd, a listener must be added in the runtime script. If you are running a full node (for example) you might already be familiar with <a href="https://github.com/handshake-org/hsd/blob/master/bin/node">the hsd full node launch script</a>, which instantiates a <code>FullNode</code> object, adds a wallet, and begins the connection and synchronization process. The script ends with an <code>async</code> function that actually starts these processes, and this is a good place to add event listeners. <a href="#events-directory">Using the table below</a> you can discover which object needs to be listened <code>on</code> for each event type. Notice that because the wallet is added as a plugin, its object hierarchy path is a little… awkward :-)</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb1-1"><a href="#cb1-1"></a><span class="co">// Based on https://github.com/handshake-org/hsd/blob/master/bin/node</span></span>
 <span id="cb1-2"><a href="#cb1-2"></a></span>
-<span id="cb1-3"><a href="#cb1-3"></a>(<span class="kw">async</span> () <span class="kw">=&gt;</span> {</span>
-<span id="cb1-4"><a href="#cb1-4"></a>  <span class="cf">await</span> node<span class="op">.</span><span class="fu">ensure</span>()<span class="op">;</span></span>
-<span id="cb1-5"><a href="#cb1-5"></a>  <span class="cf">await</span> node<span class="op">.</span><span class="fu">open</span>()<span class="op">;</span></span>
-<span id="cb1-6"><a href="#cb1-6"></a>  <span class="cf">await</span> node<span class="op">.</span><span class="fu">connect</span>()<span class="op">;</span></span>
-<span id="cb1-7"><a href="#cb1-7"></a>  node<span class="op">.</span><span class="fu">startSync</span>()<span class="op">;</span></span>
+<span id="cb1-3"><a href="#cb1-3"></a>(<span class="kw">async</span> () <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb1-4"><a href="#cb1-4"></a>  <span class="cf">await</span> <span class="va">node</span>.<span class="at">ensure</span>()<span class="op">;</span></span>
+<span id="cb1-5"><a href="#cb1-5"></a>  <span class="cf">await</span> <span class="va">node</span>.<span class="at">open</span>()<span class="op">;</span></span>
+<span id="cb1-6"><a href="#cb1-6"></a>  <span class="cf">await</span> <span class="va">node</span>.<span class="at">connect</span>()<span class="op">;</span></span>
+<span id="cb1-7"><a href="#cb1-7"></a>  <span class="va">node</span>.<span class="at">startSync</span>()<span class="op">;</span></span>
 <span id="cb1-8"><a href="#cb1-8"></a></span>
 <span id="cb1-9"><a href="#cb1-9"></a>  <span class="co">// add event listeners after everything is open, connected, and started</span></span>
 <span id="cb1-10"><a href="#cb1-10"></a></span>
 <span id="cb1-11"><a href="#cb1-11"></a>  <span class="co">// NODE</span></span>
-<span id="cb1-12"><a href="#cb1-12"></a>  node<span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;tx&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
-<span id="cb1-13"><a href="#cb1-13"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- node tx -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-14"><a href="#cb1-14"></a>  })<span class="op">;</span></span>
+<span id="cb1-12"><a href="#cb1-12"></a>  <span class="va">node</span>.<span class="at">on</span>(<span class="st">&#39;tx&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb1-13"><a href="#cb1-13"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- node tx -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-14"><a href="#cb1-14"></a>  <span class="op">}</span>)<span class="op">;</span></span>
 <span id="cb1-15"><a href="#cb1-15"></a>  </span>
-<span id="cb1-16"><a href="#cb1-16"></a>  node<span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;block&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
-<span id="cb1-17"><a href="#cb1-17"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- node block -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-18"><a href="#cb1-18"></a>  })<span class="op">;</span></span>
+<span id="cb1-16"><a href="#cb1-16"></a>  <span class="va">node</span>.<span class="at">on</span>(<span class="st">&#39;block&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb1-17"><a href="#cb1-17"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- node block -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-18"><a href="#cb1-18"></a>  <span class="op">}</span>)<span class="op">;</span></span>
 <span id="cb1-19"><a href="#cb1-19"></a></span>
 <span id="cb1-20"><a href="#cb1-20"></a>  <span class="co">// MEMPOOL</span></span>
-<span id="cb1-21"><a href="#cb1-21"></a>  node<span class="op">.</span><span class="at">mempool</span><span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;confirmed&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
-<span id="cb1-22"><a href="#cb1-22"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- mempool confirmed -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-23"><a href="#cb1-23"></a>  })<span class="op">;</span></span>
+<span id="cb1-21"><a href="#cb1-21"></a>  <span class="va">node</span>.<span class="va">mempool</span>.<span class="at">on</span>(<span class="st">&#39;confirmed&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb1-22"><a href="#cb1-22"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- mempool confirmed -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-23"><a href="#cb1-23"></a>  <span class="op">}</span>)<span class="op">;</span></span>
 <span id="cb1-24"><a href="#cb1-24"></a></span>
 <span id="cb1-25"><a href="#cb1-25"></a>  <span class="co">// WALLET</span></span>
-<span id="cb1-26"><a href="#cb1-26"></a>  node<span class="op">.</span><span class="at">plugins</span><span class="op">.</span><span class="at">walletdb</span><span class="op">.</span><span class="at">wdb</span><span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;balance&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
-<span id="cb1-27"><a href="#cb1-27"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- wallet balance -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-28"><a href="#cb1-28"></a>  })<span class="op">;</span></span>
+<span id="cb1-26"><a href="#cb1-26"></a>  <span class="va">node</span>.<span class="va">plugins</span>.<span class="va">walletdb</span>.<span class="va">wdb</span>.<span class="at">on</span>(<span class="st">&#39;balance&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb1-27"><a href="#cb1-27"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- wallet balance -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-28"><a href="#cb1-28"></a>  <span class="op">}</span>)<span class="op">;</span></span>
 <span id="cb1-29"><a href="#cb1-29"></a></span>
-<span id="cb1-30"><a href="#cb1-30"></a>  node<span class="op">.</span><span class="at">plugins</span><span class="op">.</span><span class="at">walletdb</span><span class="op">.</span><span class="at">wdb</span><span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;confirmed&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
-<span id="cb1-31"><a href="#cb1-31"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- wallet confirmed -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-32"><a href="#cb1-32"></a>  })<span class="op">;</span></span>
+<span id="cb1-30"><a href="#cb1-30"></a>  <span class="va">node</span>.<span class="va">plugins</span>.<span class="va">walletdb</span>.<span class="va">wdb</span>.<span class="at">on</span>(<span class="st">&#39;confirmed&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb1-31"><a href="#cb1-31"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- wallet confirmed -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-32"><a href="#cb1-32"></a>  <span class="op">}</span>)<span class="op">;</span></span>
 <span id="cb1-33"><a href="#cb1-33"></a></span>
-<span id="cb1-34"><a href="#cb1-34"></a>  node<span class="op">.</span><span class="at">plugins</span><span class="op">.</span><span class="at">walletdb</span><span class="op">.</span><span class="at">wdb</span><span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;address&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> {</span>
-<span id="cb1-35"><a href="#cb1-35"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39; -- wallet address -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
-<span id="cb1-36"><a href="#cb1-36"></a>  })<span class="op">;</span></span>
+<span id="cb1-34"><a href="#cb1-34"></a>  <span class="va">node</span>.<span class="va">plugins</span>.<span class="va">walletdb</span>.<span class="va">wdb</span>.<span class="at">on</span>(<span class="st">&#39;address&#39;</span><span class="op">,</span> (details) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb1-35"><a href="#cb1-35"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39; -- wallet address -- </span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> details)</span>
+<span id="cb1-36"><a href="#cb1-36"></a>  <span class="op">}</span>)<span class="op">;</span></span>
 <span id="cb1-37"><a href="#cb1-37"></a></span>
-<span id="cb1-38"><a href="#cb1-38"></a>})()<span class="op">.</span><span class="fu">catch</span>((err) <span class="kw">=&gt;</span> {</span>
-<span id="cb1-39"><a href="#cb1-39"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">error</span>(err<span class="op">.</span><span class="at">stack</span>)<span class="op">;</span></span>
-<span id="cb1-40"><a href="#cb1-40"></a>  <span class="bu">process</span><span class="op">.</span><span class="fu">exit</span>(<span class="dv">1</span>)<span class="op">;</span></span>
-<span id="cb1-41"><a href="#cb1-41"></a>})<span class="op">;</span></span></code></pre></div>
+<span id="cb1-38"><a href="#cb1-38"></a><span class="op">}</span>)().<span class="at">catch</span>((err) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb1-39"><a href="#cb1-39"></a>  <span class="va">console</span>.<span class="at">error</span>(<span class="va">err</span>.<span class="at">stack</span>)<span class="op">;</span></span>
+<span id="cb1-40"><a href="#cb1-40"></a>  <span class="va">process</span>.<span class="at">exit</span>(<span class="dv">1</span>)<span class="op">;</span></span>
+<span id="cb1-41"><a href="#cb1-41"></a><span class="op">}</span>)<span class="op">;</span></span></code></pre></div>
 <h2 id="events-directory">Events Directory</h2>
 <p>This list is comprehensive for all Handshake transaction, wallet, and blockchain activity. Events regarding errors, socket connections and peer connections have been omitted for clarity. Notice that certain methods emit the same events but with different return objects, and not all re-emitters return everything they receive.</p>
 <table>
@@ -277,66 +277,66 @@
 <p>To make a socket connection to hsd, you need to run a websocket client. Luckily the bcoin and hsd developers have developed <a href="https://github.com/bcoin-org/bsock">bsock</a>, a minimal websocket-only implementation of the socket.io protocol. By default, bsock listens on <code>localhost</code>, and you only need to pass it a port number to connect to one of the hsd servers. The example below illustrates how to establish the socket connection, authenticate with your user-defined <a href="https://handshake-org.github.io/api-docs/#authentication">API key</a> and then send and receive events! <a href="#socket-events-directory">See the tables below for a complete list of calls and events available in hsd.</a></p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb2-1"><a href="#cb2-1"></a><span class="co">// bsock-example.js</span></span>
 <span id="cb2-2"><a href="#cb2-2"></a></span>
-<span id="cb2-3"><a href="#cb2-3"></a><span class="kw">const</span> bsock <span class="op">=</span> <span class="pp">require</span>(<span class="st">&#39;bsock&#39;</span>)<span class="op">;</span></span>
-<span id="cb2-4"><a href="#cb2-4"></a><span class="kw">const</span> {Network<span class="op">,</span> ChainEntry} <span class="op">=</span> <span class="pp">require</span>(<span class="st">&#39;hsd&#39;</span>)<span class="op">;</span></span>
-<span id="cb2-5"><a href="#cb2-5"></a><span class="kw">const</span> network <span class="op">=</span> Network<span class="op">.</span><span class="fu">get</span>(<span class="st">&#39;regtest&#39;</span>)<span class="op">;</span></span>
+<span id="cb2-3"><a href="#cb2-3"></a><span class="kw">const</span> bsock <span class="op">=</span> <span class="at">require</span>(<span class="st">&#39;bsock&#39;</span>)<span class="op">;</span></span>
+<span id="cb2-4"><a href="#cb2-4"></a><span class="kw">const</span> <span class="op">{</span>Network<span class="op">,</span> ChainEntry<span class="op">}</span> <span class="op">=</span> <span class="at">require</span>(<span class="st">&#39;hsd&#39;</span>)<span class="op">;</span></span>
+<span id="cb2-5"><a href="#cb2-5"></a><span class="kw">const</span> network <span class="op">=</span> <span class="va">Network</span>.<span class="at">get</span>(<span class="st">&#39;regtest&#39;</span>)<span class="op">;</span></span>
 <span id="cb2-6"><a href="#cb2-6"></a><span class="kw">const</span> apiKey <span class="op">=</span> <span class="st">&#39;api-key&#39;</span><span class="op">;</span></span>
 <span id="cb2-7"><a href="#cb2-7"></a></span>
-<span id="cb2-8"><a href="#cb2-8"></a>nodeSocket <span class="op">=</span> bsock<span class="op">.</span><span class="fu">connect</span>(network<span class="op">.</span><span class="at">rpcPort</span>)<span class="op">;</span></span>
-<span id="cb2-9"><a href="#cb2-9"></a>walletSocket <span class="op">=</span> bsock<span class="op">.</span><span class="fu">connect</span>(network<span class="op">.</span><span class="at">walletPort</span>)<span class="op">;</span></span>
+<span id="cb2-8"><a href="#cb2-8"></a>nodeSocket <span class="op">=</span> <span class="va">bsock</span>.<span class="at">connect</span>(<span class="va">network</span>.<span class="at">rpcPort</span>)<span class="op">;</span></span>
+<span id="cb2-9"><a href="#cb2-9"></a>walletSocket <span class="op">=</span> <span class="va">bsock</span>.<span class="at">connect</span>(<span class="va">network</span>.<span class="at">walletPort</span>)<span class="op">;</span></span>
 <span id="cb2-10"><a href="#cb2-10"></a></span>
-<span id="cb2-11"><a href="#cb2-11"></a>nodeSocket<span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;connect&#39;</span><span class="op">,</span> <span class="kw">async</span> (e) <span class="kw">=&gt;</span> {</span>
-<span id="cb2-12"><a href="#cb2-12"></a>  <span class="cf">try</span> {</span>
-<span id="cb2-13"><a href="#cb2-13"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Connect event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
+<span id="cb2-11"><a href="#cb2-11"></a><span class="va">nodeSocket</span>.<span class="at">on</span>(<span class="st">&#39;connect&#39;</span><span class="op">,</span> <span class="kw">async</span> (e) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb2-12"><a href="#cb2-12"></a>  <span class="cf">try</span> <span class="op">{</span></span>
+<span id="cb2-13"><a href="#cb2-13"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Connect event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
 <span id="cb2-14"><a href="#cb2-14"></a></span>
 <span id="cb2-15"><a href="#cb2-15"></a>    <span class="co">// `auth` must be called before any other actions</span></span>
-<span id="cb2-16"><a href="#cb2-16"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Attempting auth:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> nodeSocket<span class="op">.</span><span class="fu">call</span>(<span class="st">&#39;auth&#39;</span><span class="op">,</span> apiKey))<span class="op">;</span></span>
+<span id="cb2-16"><a href="#cb2-16"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Attempting auth:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> <span class="va">nodeSocket</span>.<span class="at">call</span>(<span class="st">&#39;auth&#39;</span><span class="op">,</span> apiKey))<span class="op">;</span></span>
 <span id="cb2-17"><a href="#cb2-17"></a></span>
 <span id="cb2-18"><a href="#cb2-18"></a>    <span class="co">// `watch chain` subscirbes us to chain events like `block`</span></span>
-<span id="cb2-19"><a href="#cb2-19"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Attempting watch chain:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> nodeSocket<span class="op">.</span><span class="fu">call</span>(<span class="st">&#39;watch chain&#39;</span>))<span class="op">;</span></span>
+<span id="cb2-19"><a href="#cb2-19"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Attempting watch chain:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> <span class="va">nodeSocket</span>.<span class="at">call</span>(<span class="st">&#39;watch chain&#39;</span>))<span class="op">;</span></span>
 <span id="cb2-20"><a href="#cb2-20"></a></span>
 <span id="cb2-21"><a href="#cb2-21"></a>    <span class="co">// Some calls simply request information from the server like an http request</span></span>
-<span id="cb2-22"><a href="#cb2-22"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Attempting get tip:&#39;</span>)<span class="op">;</span></span>
-<span id="cb2-23"><a href="#cb2-23"></a>    <span class="kw">const</span> tip <span class="op">=</span> <span class="cf">await</span> nodeSocket<span class="op">.</span><span class="fu">call</span>(<span class="st">&#39;get tip&#39;</span>)<span class="op">;</span></span>
-<span id="cb2-24"><a href="#cb2-24"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(ChainEntry<span class="op">.</span><span class="fu">from</span>(tip))<span class="op">;</span></span>
+<span id="cb2-22"><a href="#cb2-22"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Attempting get tip:&#39;</span>)<span class="op">;</span></span>
+<span id="cb2-23"><a href="#cb2-23"></a>    <span class="kw">const</span> tip <span class="op">=</span> <span class="cf">await</span> <span class="va">nodeSocket</span>.<span class="at">call</span>(<span class="st">&#39;get tip&#39;</span>)<span class="op">;</span></span>
+<span id="cb2-24"><a href="#cb2-24"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="va">ChainEntry</span>.<span class="at">from</span>(tip))<span class="op">;</span></span>
 <span id="cb2-25"><a href="#cb2-25"></a></span>
-<span id="cb2-26"><a href="#cb2-26"></a>  } <span class="cf">catch</span> (e) {</span>
-<span id="cb2-27"><a href="#cb2-27"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Connection Error:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
-<span id="cb2-28"><a href="#cb2-28"></a>  } </span>
-<span id="cb2-29"><a href="#cb2-29"></a>})<span class="op">;</span></span>
+<span id="cb2-26"><a href="#cb2-26"></a>  <span class="op">}</span> <span class="cf">catch</span> (e) <span class="op">{</span></span>
+<span id="cb2-27"><a href="#cb2-27"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Connection Error:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
+<span id="cb2-28"><a href="#cb2-28"></a>  <span class="op">}</span> </span>
+<span id="cb2-29"><a href="#cb2-29"></a><span class="op">}</span>)<span class="op">;</span></span>
 <span id="cb2-30"><a href="#cb2-30"></a></span>
 <span id="cb2-31"><a href="#cb2-31"></a><span class="co">// listen for new blocks</span></span>
-<span id="cb2-32"><a href="#cb2-32"></a>nodeSocket<span class="op">.</span><span class="fu">bind</span>(<span class="st">&#39;chain connect&#39;</span><span class="op">,</span> (raw<span class="op">,</span> txs) <span class="kw">=&gt;</span> {</span>
-<span id="cb2-33"><a href="#cb2-33"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Chain Connect Event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> ChainEntry<span class="op">.</span><span class="fu">fromRaw</span>(raw))<span class="op">;</span></span>
-<span id="cb2-34"><a href="#cb2-34"></a>})<span class="op">;</span></span>
+<span id="cb2-32"><a href="#cb2-32"></a><span class="va">nodeSocket</span>.<span class="at">bind</span>(<span class="st">&#39;chain connect&#39;</span><span class="op">,</span> (raw<span class="op">,</span> txs) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb2-33"><a href="#cb2-33"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Chain Connect Event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="va">ChainEntry</span>.<span class="at">fromRaw</span>(raw))<span class="op">;</span></span>
+<span id="cb2-34"><a href="#cb2-34"></a><span class="op">}</span>)<span class="op">;</span></span>
 <span id="cb2-35"><a href="#cb2-35"></a></span>
-<span id="cb2-36"><a href="#cb2-36"></a>walletSocket<span class="op">.</span><span class="fu">on</span>(<span class="st">&#39;connect&#39;</span><span class="op">,</span> <span class="kw">async</span> (e) <span class="kw">=&gt;</span> {</span>
-<span id="cb2-37"><a href="#cb2-37"></a>  <span class="cf">try</span> {</span>
-<span id="cb2-38"><a href="#cb2-38"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Connect event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
+<span id="cb2-36"><a href="#cb2-36"></a><span class="va">walletSocket</span>.<span class="at">on</span>(<span class="st">&#39;connect&#39;</span><span class="op">,</span> <span class="kw">async</span> (e) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb2-37"><a href="#cb2-37"></a>  <span class="cf">try</span> <span class="op">{</span></span>
+<span id="cb2-38"><a href="#cb2-38"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Connect event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
 <span id="cb2-39"><a href="#cb2-39"></a></span>
 <span id="cb2-40"><a href="#cb2-40"></a>    <span class="co">// `auth` is required before proceeding</span></span>
-<span id="cb2-41"><a href="#cb2-41"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Attempting auth:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> walletSocket<span class="op">.</span><span class="fu">call</span>(<span class="st">&#39;auth&#39;</span><span class="op">,</span> apiKey))<span class="op">;</span></span>
+<span id="cb2-41"><a href="#cb2-41"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Attempting auth:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> <span class="va">walletSocket</span>.<span class="at">call</span>(<span class="st">&#39;auth&#39;</span><span class="op">,</span> apiKey))<span class="op">;</span></span>
 <span id="cb2-42"><a href="#cb2-42"></a></span>
 <span id="cb2-43"><a href="#cb2-43"></a>    <span class="co">// here we join all wallets, but we could also just join `primary` or any other wallet</span></span>
-<span id="cb2-44"><a href="#cb2-44"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Attempting join *:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> walletSocket<span class="op">.</span><span class="fu">call</span>(<span class="st">&#39;join&#39;</span><span class="op">,</span> <span class="st">&#39;*&#39;</span>))<span class="op">;</span></span>
+<span id="cb2-44"><a href="#cb2-44"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Attempting join *:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="cf">await</span> <span class="va">walletSocket</span>.<span class="at">call</span>(<span class="st">&#39;join&#39;</span><span class="op">,</span> <span class="st">&#39;*&#39;</span>))<span class="op">;</span></span>
 <span id="cb2-45"><a href="#cb2-45"></a></span>
-<span id="cb2-46"><a href="#cb2-46"></a>  } <span class="cf">catch</span> (e) {</span>
-<span id="cb2-47"><a href="#cb2-47"></a>    <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Connection Error:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
-<span id="cb2-48"><a href="#cb2-48"></a>  } </span>
-<span id="cb2-49"><a href="#cb2-49"></a>})<span class="op">;</span></span>
+<span id="cb2-46"><a href="#cb2-46"></a>  <span class="op">}</span> <span class="cf">catch</span> (e) <span class="op">{</span></span>
+<span id="cb2-47"><a href="#cb2-47"></a>    <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Connection Error:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> e)<span class="op">;</span></span>
+<span id="cb2-48"><a href="#cb2-48"></a>  <span class="op">}</span> </span>
+<span id="cb2-49"><a href="#cb2-49"></a><span class="op">}</span>)<span class="op">;</span></span>
 <span id="cb2-50"><a href="#cb2-50"></a></span>
 <span id="cb2-51"><a href="#cb2-51"></a><span class="co">// listen for new wallet transactions</span></span>
-<span id="cb2-52"><a href="#cb2-52"></a>walletSocket<span class="op">.</span><span class="fu">bind</span>(<span class="st">&#39;tx&#39;</span><span class="op">,</span> (wallet<span class="op">,</span> tx) <span class="kw">=&gt;</span> {</span>
-<span id="cb2-53"><a href="#cb2-53"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - TX Event -- wallet:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> wallet)<span class="op">;</span></span>
-<span id="cb2-54"><a href="#cb2-54"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - TX Event -- tx:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> tx)<span class="op">;</span></span>
-<span id="cb2-55"><a href="#cb2-55"></a>})<span class="op">;</span></span>
+<span id="cb2-52"><a href="#cb2-52"></a><span class="va">walletSocket</span>.<span class="at">bind</span>(<span class="st">&#39;tx&#39;</span><span class="op">,</span> (wallet<span class="op">,</span> tx) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb2-53"><a href="#cb2-53"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - TX Event -- wallet:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> wallet)<span class="op">;</span></span>
+<span id="cb2-54"><a href="#cb2-54"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - TX Event -- tx:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> tx)<span class="op">;</span></span>
+<span id="cb2-55"><a href="#cb2-55"></a><span class="op">}</span>)<span class="op">;</span></span>
 <span id="cb2-56"><a href="#cb2-56"></a></span>
 <span id="cb2-57"><a href="#cb2-57"></a><span class="co">// listen for new address events</span></span>
 <span id="cb2-58"><a href="#cb2-58"></a><span class="co">// (only fired when current account address receives a transaction)</span></span>
-<span id="cb2-59"><a href="#cb2-59"></a>walletSocket<span class="op">.</span><span class="fu">bind</span>(<span class="st">&#39;address&#39;</span><span class="op">,</span> (wallet<span class="op">,</span> json) <span class="kw">=&gt;</span> {</span>
-<span id="cb2-60"><a href="#cb2-60"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Address Event -- wallet:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> wallet)<span class="op">;</span></span>
-<span id="cb2-61"><a href="#cb2-61"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Wallet - Address Event -- json:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> json)<span class="op">;</span></span>
-<span id="cb2-62"><a href="#cb2-62"></a>})<span class="op">;</span></span></code></pre></div>
+<span id="cb2-59"><a href="#cb2-59"></a><span class="va">walletSocket</span>.<span class="at">bind</span>(<span class="st">&#39;address&#39;</span><span class="op">,</span> (wallet<span class="op">,</span> json) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb2-60"><a href="#cb2-60"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Address Event -- wallet:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> wallet)<span class="op">;</span></span>
+<span id="cb2-61"><a href="#cb2-61"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Wallet - Address Event -- json:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> json)<span class="op">;</span></span>
+<span id="cb2-62"><a href="#cb2-62"></a><span class="op">}</span>)<span class="op">;</span></span></code></pre></div>
 <p>To see this script in action, first start hsd however you usually do:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1"></a><span class="ex">hsd</span> --daemon --network=regtest</span></code></pre></div>
 <p>Run the script (this is where the event output will be printed):</p>
@@ -347,30 +347,30 @@
 <p><code>bsock</code> is a great low-level library for dealing with sockets, but we also have <a href="https://github.com/handshake-org/hs-client">hs-client</a> which simplifies both socket and regular http connections. A simple one-line command in the terminal can listen to all wallet events and print all the returned data:</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1"></a><span class="ex">hsw-cli</span> listen</span></code></pre></div>
 <p><code>hs-client</code> can also be used in a script to listen for events. If you’re already familiar with the <a href="https://handshake-org.github.io/api-docs">hsd-cli API</a> this will look very familiar. Here’s part of the script above re-written using <code>hs-client</code> instead of <code>bsock</code>:</p>
-<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1"></a><span class="kw">const</span> {NodeClient} <span class="op">=</span> <span class="pp">require</span>(<span class="st">&#39;hs-client&#39;</span>)<span class="op">;</span></span>
-<span id="cb7-2"><a href="#cb7-2"></a><span class="kw">const</span> {Network<span class="op">,</span> ChainEntry} <span class="op">=</span> <span class="pp">require</span>(<span class="st">&#39;hsd&#39;</span>)<span class="op">;</span></span>
-<span id="cb7-3"><a href="#cb7-3"></a><span class="kw">const</span> network <span class="op">=</span> Network<span class="op">.</span><span class="fu">get</span>(<span class="st">&#39;regtest&#39;</span>)<span class="op">;</span></span>
+<div class="sourceCode" id="cb7"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span id="cb7-1"><a href="#cb7-1"></a><span class="kw">const</span> <span class="op">{</span>NodeClient<span class="op">}</span> <span class="op">=</span> <span class="at">require</span>(<span class="st">&#39;hs-client&#39;</span>)<span class="op">;</span></span>
+<span id="cb7-2"><a href="#cb7-2"></a><span class="kw">const</span> <span class="op">{</span>Network<span class="op">,</span> ChainEntry<span class="op">}</span> <span class="op">=</span> <span class="at">require</span>(<span class="st">&#39;hsd&#39;</span>)<span class="op">;</span></span>
+<span id="cb7-3"><a href="#cb7-3"></a><span class="kw">const</span> network <span class="op">=</span> <span class="va">Network</span>.<span class="at">get</span>(<span class="st">&#39;regtest&#39;</span>)<span class="op">;</span></span>
 <span id="cb7-4"><a href="#cb7-4"></a></span>
-<span id="cb7-5"><a href="#cb7-5"></a><span class="kw">const</span> clientOptions <span class="op">=</span> {</span>
-<span id="cb7-6"><a href="#cb7-6"></a>  <span class="dt">network</span><span class="op">:</span> network<span class="op">.</span><span class="at">type</span><span class="op">,</span></span>
-<span id="cb7-7"><a href="#cb7-7"></a>  <span class="dt">port</span><span class="op">:</span> network<span class="op">.</span><span class="at">rpcPort</span><span class="op">,</span></span>
+<span id="cb7-5"><a href="#cb7-5"></a><span class="kw">const</span> clientOptions <span class="op">=</span> <span class="op">{</span></span>
+<span id="cb7-6"><a href="#cb7-6"></a>  <span class="dt">network</span><span class="op">:</span> <span class="va">network</span>.<span class="at">type</span><span class="op">,</span></span>
+<span id="cb7-7"><a href="#cb7-7"></a>  <span class="dt">port</span><span class="op">:</span> <span class="va">network</span>.<span class="at">rpcPort</span><span class="op">,</span></span>
 <span id="cb7-8"><a href="#cb7-8"></a>  <span class="dt">apiKey</span><span class="op">:</span> <span class="st">&#39;api-key&#39;</span></span>
-<span id="cb7-9"><a href="#cb7-9"></a>}</span>
-<span id="cb7-10"><a href="#cb7-10"></a><span class="kw">const</span> client <span class="op">=</span> <span class="kw">new</span> NodeClient(clientOptions)<span class="op">;</span></span>
+<span id="cb7-9"><a href="#cb7-9"></a><span class="op">}</span></span>
+<span id="cb7-10"><a href="#cb7-10"></a><span class="kw">const</span> client <span class="op">=</span> <span class="kw">new</span> <span class="at">NodeClient</span>(clientOptions)<span class="op">;</span></span>
 <span id="cb7-11"><a href="#cb7-11"></a></span>
-<span id="cb7-12"><a href="#cb7-12"></a>(<span class="kw">async</span> () <span class="kw">=&gt;</span> {</span>
+<span id="cb7-12"><a href="#cb7-12"></a>(<span class="kw">async</span> () <span class="kw">=&gt;</span> <span class="op">{</span></span>
 <span id="cb7-13"><a href="#cb7-13"></a>  <span class="co">// bclient handles the connection, the auth, and the channel subscriptions</span></span>
-<span id="cb7-14"><a href="#cb7-14"></a>  <span class="cf">await</span> client<span class="op">.</span><span class="fu">open</span>()<span class="op">;</span></span>
+<span id="cb7-14"><a href="#cb7-14"></a>  <span class="cf">await</span> <span class="va">client</span>.<span class="at">open</span>()<span class="op">;</span></span>
 <span id="cb7-15"><a href="#cb7-15"></a></span>
 <span id="cb7-16"><a href="#cb7-16"></a>  <span class="co">// use socket connection to request data</span></span>
-<span id="cb7-17"><a href="#cb7-17"></a>  <span class="kw">const</span> tip <span class="op">=</span> <span class="cf">await</span> client<span class="op">.</span><span class="fu">getTip</span>()<span class="op">;</span></span>
-<span id="cb7-18"><a href="#cb7-18"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(tip)<span class="op">;</span></span>
-<span id="cb7-19"><a href="#cb7-19"></a>})()<span class="op">;</span></span>
+<span id="cb7-17"><a href="#cb7-17"></a>  <span class="kw">const</span> tip <span class="op">=</span> <span class="cf">await</span> <span class="va">client</span>.<span class="at">getTip</span>()<span class="op">;</span></span>
+<span id="cb7-18"><a href="#cb7-18"></a>  <span class="va">console</span>.<span class="at">log</span>(tip)<span class="op">;</span></span>
+<span id="cb7-19"><a href="#cb7-19"></a><span class="op">}</span>)()<span class="op">;</span></span>
 <span id="cb7-20"><a href="#cb7-20"></a></span>
 <span id="cb7-21"><a href="#cb7-21"></a><span class="co">// listen for new blocks</span></span>
-<span id="cb7-22"><a href="#cb7-22"></a>client<span class="op">.</span><span class="fu">bind</span>(<span class="st">&#39;chain connect&#39;</span><span class="op">,</span> (raw) <span class="kw">=&gt;</span> {</span>
-<span id="cb7-23"><a href="#cb7-23"></a>  <span class="bu">console</span><span class="op">.</span><span class="fu">log</span>(<span class="st">&#39;Node - Chain Connect Event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> ChainEntry<span class="op">.</span><span class="fu">fromRaw</span>(raw))<span class="op">;</span></span>
-<span id="cb7-24"><a href="#cb7-24"></a>})<span class="op">;</span></span></code></pre></div>
+<span id="cb7-22"><a href="#cb7-22"></a><span class="va">client</span>.<span class="at">bind</span>(<span class="st">&#39;chain connect&#39;</span><span class="op">,</span> (raw) <span class="kw">=&gt;</span> <span class="op">{</span></span>
+<span id="cb7-23"><a href="#cb7-23"></a>  <span class="va">console</span>.<span class="at">log</span>(<span class="st">&#39;Node - Chain Connect Event:</span><span class="sc">\n</span><span class="st">&#39;</span><span class="op">,</span> <span class="va">ChainEntry</span>.<span class="at">fromRaw</span>(raw))<span class="op">;</span></span>
+<span id="cb7-24"><a href="#cb7-24"></a><span class="op">}</span>)<span class="op">;</span></span></code></pre></div>
 <h2 id="socket-events-directory">Socket Events Directory</h2>
 <h3 id="wallet">Wallet</h3>
 <p>All wallet events are emitted by a <code>WalletDB</code> object, which may have been triggered by its parent <code>TXDB</code> or <code>Wallet</code>. The socket emits the event along with the wallet ID, and the same “Returns” as listed above.</p>

--- a/guides/protocol.html
+++ b/guides/protocol.html
@@ -34,7 +34,7 @@
     <li><a id="guides-claims"   href="/guides/claims.html">Name Claims</a></li>
     <li><a id="guides-auctions"   href="/guides/auctions.html">Name Auctions</a></li>
     <li><a id="guides-wallet"   href="/guides/wallet.html">Wallet Setup</a></li>
-    <li><a id="guides-protocol"   href="/guides/protocol.html">Protocol Summary</a></li>
+    <li><a id="guides-protocol"  class="active"  href="/guides/protocol.html">Protocol Summary</a></li>
   </ul>
   <ul>
     <li><strong>DOCUMENTATION</strong></li>

--- a/guides/wallet.html
+++ b/guides/wallet.html
@@ -34,7 +34,7 @@
     <li><a id="guides-claims"   href="/guides/claims.html">Name Claims</a></li>
     <li><a id="guides-auctions"   href="/guides/auctions.html">Name Auctions</a></li>
     <li><a id="guides-wallet"  class="active"  href="/guides/wallet.html">Wallet Setup</a></li>
-    <li><a id="guides-protocol"  class="active"  href="/guides/protocol.html">Protocol Summary</a></li>
+    <li><a id="guides-protocol"   href="/guides/protocol.html">Protocol Summary</a></li>
   </ul>
   <ul>
     <li><strong>DOCUMENTATION</strong></li>

--- a/src/api-docs/source/includes/_coin.md
+++ b/src/api-docs/source/includes/_coin.md
@@ -28,7 +28,7 @@ index=0;
 ```
 
 ```shell--curl
-curl $url/coin/$hash/$index
+curl http://x:api-key@127.0.0.1:14037/coin/$hash/$index
 ```
 
 ```shell--cli
@@ -98,7 +98,7 @@ address='rs1qpu06wprkwleh579mureghcasjhu9uwge6pltn5';
 ```
 
 ```shell--curl
-curl $url/coin/address/$address
+curl http://x:api-key@127.0.0.1:14037/coin/address/$address
 ```
 
 ```shell--cli
@@ -189,7 +189,7 @@ address1='rs1qcxuurryemelaj64k6rswn8x9aa8nd9nafa47ag';
 ```
 
 ```shell--curl
-curl $url/coin/address \
+curl http://x:api-key@127.0.0.1:14037/coin/address \
   -H 'Content-Type: application/json' \
   -X POST \
   --data '{ "addresses":[ "'$address0'", "'$address1'" ]}'

--- a/src/api-docs/source/includes/_node.md
+++ b/src/api-docs/source/includes/_node.md
@@ -28,7 +28,7 @@ Command     				|cURL method	| Description
 ## Get server info
 
 ```shell--curl
-curl $url/
+curl http://x:api-key@127.0.0.1:14037/
 ```
 
 ```shell--cli
@@ -117,7 +117,7 @@ Get server Info.
 ## Get mempool snapshot
 
 ```shell--curl
-curl $url/mempool
+curl http://x:api-key@127.0.0.1:14037/mempool
 ```
 
 ```shell--cli
@@ -169,7 +169,7 @@ No Params.
 ## Get mempool rejects filter
 
 ```shell--curl
-curl $url/mempool/invalid
+curl http://x:api-key@127.0.0.1:14037/mempool/invalid
 ```
 
 ```shell--cli
@@ -209,7 +209,7 @@ verbose | _(bool)_ Returns entire Bloom Filter in `filter` property, hex-encoded
 
 ```shell--curl
 hash=8e4c9756fef2ad10375f360e0560fcc7587eb5223ddf8cd7c7e06e60a1140b15
-curl $url/mempool/invalid/$hash
+curl http://x:api-key@127.0.0.1:14037/mempool/invalid/$hash
 ```
 
 ```shell--cli
@@ -252,8 +252,8 @@ blockHeight='0';
 ```
 
 ```shell--curl
-curl $url/block/$blockHash # by hash
-curl $url/block/$blockHeight # by height
+curl http://x:api-key@127.0.0.1:14037/block/$blockHash # by hash
+curl http://x:api-key@127.0.0.1:14037/block/$blockHeight # by height
 ```
 
 ```shell--cli
@@ -366,8 +366,8 @@ blockHeight='0';
 ```
 
 ```shell--curl
-curl $url/header/$blockHash # by hash
-curl $url/header/$blockHeight # by height
+curl http://x:api-key@127.0.0.1:14037/header/$blockHash # by hash
+curl http://x:api-key@127.0.0.1:14037/header/$blockHeight # by height
 ```
 
 ```shell--cli
@@ -421,7 +421,7 @@ tx='010000000106b014e37704109fefe2c5c9f4227d68840c3497fc89a9832db8504df039a6c700
 ```
 
 ```shell--curl
-curl $url/broadcast \
+curl http://x:api-key@127.0.0.1:14037/broadcast \
   -H 'Content-Type: application/json' \
   -X POST \
   --data '{ "tx": "'$tx'" }'
@@ -479,7 +479,7 @@ claim='310d030300003000010002a30001080101030803010001acffb409bcc939f...';
 ```
 
 ```shell--curl
-curl $url/claim \
+curl http://x:api-key@127.0.0.1:14037/claim \
   -H 'Content-Type: application/json' \
   -X POST \
   --data '{ "claim": "'$claim'" }'
@@ -537,7 +537,7 @@ blocks=3
 ```
 
 ```shell--curl
-curl $url/fee?blocks=$blocks
+curl http://x:api-key@127.0.0.1:14037/fee?blocks=$blocks
 ```
 
 ```shell--cli
@@ -592,7 +592,7 @@ height=1000;
 ```
 
 ```shell--curl
-curl $url/reset \
+curl http://x:api-key@127.0.0.1:14037/reset \
   -H 'Content-Type: application/json' \
   -X POST \
   --data '{ "height": '$height' }'

--- a/src/api-docs/source/includes/_node_rpc.md
+++ b/src/api-docs/source/includes/_node_rpc.md
@@ -1,7 +1,7 @@
 # RPC Calls - Node
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{ "method": "<method>", "params": [...] "id": "some-id" }'
 ```

--- a/src/api-docs/source/includes/_node_rpc_block.md
+++ b/src/api-docs/source/includes/_node_rpc_block.md
@@ -3,7 +3,7 @@
 ## getblockchaininfo
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{ "method": "getblockchaininfo" }'
 ```
@@ -75,7 +75,7 @@ None. |
 ## getbestblockhash
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{ "method": "getbestblockhash" }'
 ```
@@ -122,7 +122,7 @@ None. |
 
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{ "method": "getblockcount" }'
 ```
@@ -178,7 +178,7 @@ details=0;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getblock",
@@ -268,7 +268,7 @@ details=0;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getblockbyheight",
@@ -356,7 +356,7 @@ blockheight=50;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getblockhash",
@@ -414,7 +414,7 @@ verbose=1;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getblockheader",
@@ -482,7 +482,7 @@ N. | Name | Default |  Description
 ## getchaintips
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getchaintips"
@@ -538,7 +538,7 @@ None. |
 ## getdifficulty
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getdifficulty"

--- a/src/api-docs/source/includes/_node_rpc_chain.md
+++ b/src/api-docs/source/includes/_node_rpc_chain.md
@@ -3,7 +3,7 @@
 ## pruneblockchain
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "pruneblockchain",
@@ -61,7 +61,7 @@ blockhash='52d7beaf4c7f392bef2744167c7f4db4bb4113b2635496edcf2d1c94128696aa';
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "invalidateblock",
@@ -117,7 +117,7 @@ blockhash='1896e628f8011b77ea80f4582c29c21b3376183683f587ee863050376add3891'
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "reconsiderblock",

--- a/src/api-docs/source/includes/_node_rpc_general.md
+++ b/src/api-docs/source/includes/_node_rpc_general.md
@@ -1,7 +1,7 @@
 ## stop
 
 ```shell--curl
-curl $url/ \
+curl http://x:api-key@127.0.0.1:14037/ \
   -H 'Content-Type: application/json' \
   -X POST \
   --data '{ "method": "stop" }'
@@ -48,7 +48,7 @@ None. |
 ## getinfo
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{ "method": "getinfo" }'
 ```
@@ -112,7 +112,7 @@ None. |
 ## getmemoryinfo
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{ "method": "getmemoryinfo" }'
 ```
@@ -165,7 +165,7 @@ None. |
 ## setloglevel
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "setloglevel",
@@ -223,7 +223,7 @@ address='rs1q7rvnwj3vaqxrwuv87j7xc6ye83tpevfkvhzsap';
 ```
 
 ```shell--curl
-curl $url/ \
+curl http://x:api-key@127.0.0.1:14037/ \
   -X POST \
   --data '{
     "method": "validateaddress",
@@ -291,7 +291,7 @@ pubkey2='034bc2280e68d3bdd0ef0664e0ad2949a467344d8e59e435fe2d9be81e39f70f76';
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "createmultisig",
@@ -352,7 +352,7 @@ message='hello';
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "signmessagewithprivkey",
@@ -413,7 +413,7 @@ message='hello';
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "verifymessage",
@@ -472,7 +472,7 @@ timestamp=1503058155;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "setmocktime",

--- a/src/api-docs/source/includes/_node_rpc_mempool.md
+++ b/src/api-docs/source/includes/_node_rpc_mempool.md
@@ -3,7 +3,7 @@
 ## getmempoolinfo
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getmempoolinfo"
@@ -66,7 +66,7 @@ verbose=1;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getmempoolancestors",
@@ -171,7 +171,7 @@ verbose=1;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getmempooldescendants",
@@ -275,7 +275,7 @@ txhash='0e690d6655767c8b388e7403d13dc9ebe49b68e3bd46248c840544f9da87d1e8';
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getmempoolentry",
@@ -349,7 +349,7 @@ verbose=1;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getrawmempool",
@@ -445,7 +445,7 @@ feeDelta=1000;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "prioritisetransaction",
@@ -507,7 +507,7 @@ nblocks=10;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "estimatefee",
@@ -564,7 +564,7 @@ nblocks=10;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "estimatepriority",
@@ -621,7 +621,7 @@ nblocks=10;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "estimatesmartfee",
@@ -681,7 +681,7 @@ nblocks=10;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "estimatesmartpriority",

--- a/src/api-docs/source/includes/_node_rpc_mining.md
+++ b/src/api-docs/source/includes/_node_rpc_mining.md
@@ -14,7 +14,7 @@ height=1000000;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getnetworkhashps",
@@ -64,7 +64,7 @@ N. | Name | Default |  Description
 ## getmininginfo
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getmininginfo",
@@ -130,7 +130,7 @@ None. |
 ## getwork
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getwork",
@@ -186,7 +186,7 @@ N. | Name | Default |  Description
 # Because there is a request timeout set on CLI http requests.
 # without manually adjusting the timeout (or receiving a new transaction on the current
 # network) this call will timeout before the request is complete.
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getworklp",
@@ -250,7 +250,7 @@ None. |
 ## getblocktemplate
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getblocktemplate",
@@ -360,7 +360,7 @@ blockdata='000000203f6397a1442eb6a9901998c4a4b432f8573c7a490b2d5e6d6f2ad0d0fca25
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "submitblock",
@@ -410,7 +410,7 @@ blockdata='000000203f6397a1442eb6a9901998c4a4b432f8573c7a490b2d5e6d6f2ad0d0fca25
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "verifyblock",
@@ -465,7 +465,7 @@ proclimit=1;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "setgenerate",
@@ -515,7 +515,7 @@ N. | Name | Default |  Description
 ## getgenerate
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getgenerate",
@@ -572,7 +572,7 @@ numblocks=2;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "generate",
@@ -638,7 +638,7 @@ address='RTZJdYScA7uGb5pbQPEczpDmq9HiYLv2fJ';
 
 ```shell--curl
 # Will return once all blocks are mined.
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "generatetoaddress",

--- a/src/api-docs/source/includes/_node_rpc_names.md
+++ b/src/api-docs/source/includes/_node_rpc_names.md
@@ -3,7 +3,7 @@
 ## getnameinfo
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{ "method": "getnameinfo", "params": [ '$name'] }'
 ```
@@ -501,7 +501,7 @@ hsd-rpc getdnssecproof "$name"
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
     -X POST \
     --data '{"method":"getdnssecproof","params":["'$name'"]}'
 ```

--- a/src/api-docs/source/includes/_node_rpc_network.md
+++ b/src/api-docs/source/includes/_node_rpc_network.md
@@ -3,7 +3,7 @@
 ## getconnectioncount
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getconnectioncount",
@@ -50,7 +50,7 @@ None. |
 ## ping
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "ping",
@@ -99,7 +99,7 @@ None. |
 ## getpeerinfo
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getpeerinfo",
@@ -186,7 +186,7 @@ cmd='add'
 
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "addnode",
@@ -252,7 +252,7 @@ nodeAddr='127.0.0.1:14038';
 
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "disconnectnode",
@@ -309,7 +309,7 @@ nodeAddr='127.0.0.1:14038';
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getaddednodeinfo",
@@ -369,7 +369,7 @@ N. | Name | Default |  Description
 ## getnettotals
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getnettotals",
@@ -422,7 +422,7 @@ None. |
 ## getnetworkinfo
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getnetworkinfo",
@@ -501,7 +501,7 @@ cmd='add'
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "setban",
@@ -557,7 +557,7 @@ remove | Removes node from ban list
 ## listbanned
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "listbanned",
@@ -613,7 +613,7 @@ None. |
 ## clearbanned
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "clearbanned",

--- a/src/api-docs/source/includes/_node_rpc_tx.md
+++ b/src/api-docs/source/includes/_node_rpc_tx.md
@@ -13,7 +13,7 @@ includemempool=1;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "gettxout",
@@ -74,7 +74,7 @@ N. | Name | Default |  Description
 ## gettxoutsetinfo
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "gettxoutsetinfo",
@@ -140,7 +140,7 @@ verbose=0;
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "getrawtransaction",
@@ -198,7 +198,7 @@ rawtx='000000000103858fc9d1c73d5250f2526ef71e17cb37d542d0fd7c8ddd061ab5f42ac47c5
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "decoderawtransaction",
@@ -306,7 +306,7 @@ script='76c014af92ad98c7f77559f96430dfef2a6805b87b24f888ac';
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "decodescript",
@@ -367,7 +367,7 @@ rawtx='0100000001eaefefbd1f687ef4e861804aed59ef05e743ea85f432cc146f325d759a026ce
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "sendrawtransaction",
@@ -428,7 +428,7 @@ data='deadbeef';
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "createrawtransaction",
@@ -513,7 +513,7 @@ privkey='ENced8VD7YWkzPC8FTJ3gTTq4pQhF2PF79QS51mgZq7BgCfiEP5A';
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "signrawtransaction",
@@ -601,7 +601,7 @@ txid1='e66c029a755d326f14cc32f485ea43e705ef59ed4a8061e8f47e681fbdefefea';
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "gettxoutproof",
@@ -660,7 +660,7 @@ proof='00000020e562d79a1ffb4f95926ed1c67baab26b7e73712369a61b134eb881205bd8110ef
 ```
 
 ```shell--curl
-curl $url \
+curl http://x:api-key@127.0.0.1:14037 \
   -X POST \
   --data '{
     "method": "verifytxoutproof",

--- a/src/api-docs/source/includes/_transaction.md
+++ b/src/api-docs/source/includes/_transaction.md
@@ -19,7 +19,7 @@ txhash='4674eb87021d9e07ff68cfaaaddfb010d799246b8f89941c58b8673386ce294f';
 ```
 
 ```shell--curl
-curl $url/tx/$txhash
+curl http://x:api-key@127.0.0.1:14037/tx/$txhash
 ```
 
 ```shell--cli
@@ -112,7 +112,7 @@ address='rs1qpu06wprkwleh579mureghcasjhu9uwge6pltn5';
 ```
 
 ```shell--curl
-curl $url/tx/address/$address
+curl http://x:api-key@127.0.0.1:14037/tx/address/$address
 ```
 
 ```shell--cli
@@ -217,7 +217,7 @@ address1='rs1qx38r5mjzlxfus9yx7nhx3mrg00sv75xc5mksk5';
 ```
 
 ```shell--curl
- curl $url/tx/address \
+ curl http://x:api-key@127.0.0.1:14037/tx/address \
   -H 'Content-Type: application/json' \
   -X POST \
   --data '{ "addresses":[ "'$address0'", "'$address1'" ]}'

--- a/src/api-docs/source/includes/_wallet.md
+++ b/src/api-docs/source/includes/_wallet.md
@@ -80,7 +80,7 @@ token='17715756779e4a5f7c9b26c48d90a09d276752625430b41b5fcf33cf41aa7615'
 ```
 
 ```shell--curl
-curl $walleturl/$id?token=$token
+curl http://x:api-key@127.0.0.1:14039/wallet/$id?token=$token
 ```
 
 ```shell--cli
@@ -154,10 +154,6 @@ id="primary"
 
 ```shell--curl
 curl http://x:api-key@127.0.0.1:14039/wallet # will list regtest (default port 14039) wallets
-
-# examples in these docs will use an environment variable:
-walleturl=http://x:api-key@127.0.0.1:14039/wallet/
-curl $walleturl/$id
 ```
 
 ```shell--cli
@@ -253,7 +249,7 @@ witness=false
 watchOnly=true
 accountKey='rpubKBAoFrCN1HzSEDye7jcQaycA8L7MjFGmJD1uuvUZ21d9srAmAxmB7o1tCZRyXmTRuy5ZDQDV6uxtcxfHAadNFtdK7J6RV9QTcHTCEoY5FtQD'
 
-curl $walleturl/$id \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id \
   -X PUT \
   --data '{"witness":'$witness', "passphrase":"'$passphrase'", "watchOnly": '$watchOnly', "accountKey":"'$accountKey'"}'
 ```
@@ -363,7 +359,7 @@ hsw-cli retoken --id=$id --passphrase=$passphrase
 ```
 
 ```shell--curl
-curl $walleturl/$id/retoken \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/retoken \
   -X POST \
   --data '{"passphrase":"'$passphrase'"}'
 ```
@@ -417,7 +413,7 @@ id='primary'
 ```
 
 ```shell--curl
-curl $walleturl/$id
+curl http://x:api-key@127.0.0.1:14039/wallet/$id
 ```
 
 ```shell--cli
@@ -491,7 +487,7 @@ id='primary'
 ```
 
 ```shell--curl
-curl $walleturl/$id/master
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/master
 ```
 
 ```shell--cli
@@ -582,7 +578,7 @@ newPass='789secret'
 ```
 
 ```shell--curl
-curl $walleturl/$id/passphrase \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/passphrase \
   -X POST \
   --data '{"old":"'$oldPass'", "passphrase":"'$newPass'"}'
 ```
@@ -649,7 +645,7 @@ rate=500
 value=1000
 address="rs1q7rvnwj3vaqxrwuv87j7xc6ye83tpevfkvhzsap"
 
-curl $walleturl/$id/send \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/send \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",
@@ -802,7 +798,7 @@ rate=500
 value=5000000
 address="rs1q7rvnwj3vaqxrwuv87j7xc6ye83tpevfkvhzsap
 
-curl $walleturl/$id/create \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/create \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",
@@ -949,7 +945,7 @@ hsw-cli sign --id=$id --passphrase=$passphrase --tx=$tx
 ```
 
 ```shell--curl
-curl $walleturl/$id/sign \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/sign \
   -X POST \
   --data '{"tx": "'$tx'", "passphrase":"'$passphrase'"}'
 ```
@@ -1060,7 +1056,7 @@ id="primary"
 account="default"
 age=259200 # 72 hours
 
-curl $walleturl/$id/zap \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/zap \
   -X POST \
   --data '{
     "account": "'$account'",
@@ -1140,7 +1136,7 @@ hsw-cli unlock --id=$id $pass $timeout
 ```
 
 ```shell--curl
-curl $walleturl/$id/unlock \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/unlock \
   -X POST \
   --data '{"passphrase":"'$pass'", "timeout": '$timeout'}'
 ```
@@ -1205,7 +1201,7 @@ hsw-cli lock --id=$id
 ```
 
 ```shell--curl
-curl $walleturl/$id/lock \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/lock \
   -X POST
 ```
 
@@ -1267,11 +1263,11 @@ hsw-cli --id=$watchid --account=$account import $pubkey
 ```
 
 ```shell--curl
-curl $walleturl/$id/import \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/import \
   -X POST \
   --data '{"account":"'$account'", "privateKey":"'$privkey'"}'
   
-curl $walleturl/$watchid/import \
+curl http://x:api-key@127.0.0.1:14039/wallet/$watchid/import \
   -X POST \
   --data '{"account":"'$account'", "publicKey":"'$pubkey'"}'
 ```
@@ -1351,7 +1347,7 @@ hsw-cli watch --id=$id --account=$account $address
 ```
 
 ```shell--curl
-curl $walleturl/$id/import \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/import \
   -X POST \
   --data '{"account":"'$account'", "address":"'$address'"}'
 ```
@@ -1408,7 +1404,7 @@ id="primary"
 ```
 
 ```shell--curl
-curl $walleturl/$id/block
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/block
 ```
 
 ```shell--cli
@@ -1465,7 +1461,7 @@ hsw-cli --id=$id block $height
 ```
 
 ```shell--curl
-curl $walleturl/$id/block/$height
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/block/$height
 ```
 
 ```javascript
@@ -1529,7 +1525,7 @@ hsw-cli --id=$id --account=$account shared add $key
 ```
 
 ```shell--curl
-curl $walleturl/$id/shared-key \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/shared-key \
   -X PUT \
   --data '{"accountKey": "'$key'", "account": "'$account'"}'
 ```
@@ -1599,7 +1595,7 @@ hsw-cli --id=$id --account=$account shared remove $key
 ```
 
 ```shell--curl
-curl $walleturl/$id/shared-key \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/shared-key \
   -X DELETE \
   --data '{"accountKey": "'$key'", "account": "'$account'"}'
 ```
@@ -1670,7 +1666,7 @@ hsw-cli --id=$id key $address
 ```
 
 ```shell--curl
-curl $walleturl/$id/key/$address
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/key/$address
 ```
 
 ```javascript
@@ -1734,7 +1730,7 @@ hsw-cli --id=$id --passphrase=$passphrase dump $address
 ```
 
 ```shell--curl
-curl $walleturl/$id/wif/$address?passphrase=$passphrase
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/wif/$address?passphrase=$passphrase
 ```
 
 ```javascript
@@ -1792,7 +1788,7 @@ hsw-cli --id=$id --account=$account address
 ```
 
 ```shell--curl
-curl $walleturl/$id/address -X POST --data '{"account":"'$account'"}'
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/address -X POST --data '{"account":"'$account'"}'
 ```
 
 ```javascript
@@ -1860,7 +1856,7 @@ hsw-cli --id=$id --account=$account change
 ```
 
 ```shell--curl
-curl $walleturl/$id/change -X POST --data '{"account":"'$account'"}'
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/change -X POST --data '{"account":"'$account'"}'
 ```
 
 ```javascript
@@ -1927,7 +1923,7 @@ hsw-cli --id=$id nested --account=$account
 ```
 
 ```shell--curl
-curl $walleturl/$id/nested -X POST --data '{"account": "'$account'"}'
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/nested -X POST --data '{"account": "'$account'"}'
 ```
 
 ```javascript
@@ -1992,7 +1988,7 @@ hsw-cli --id=$id balance --account=$account
 ```
 
 ```shell--curl
-curl $walleturl/$id/balance?account=$account
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/balance?account=$account
 ```
 
 ```javascript
@@ -2053,7 +2049,7 @@ id="primary"
 ```
 
 ```shell--curl
-curl $walleturl/$id/coin
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/coin
 ```
 
 ```shell--cli
@@ -2136,7 +2132,7 @@ index="0"
 ```
 
 ```shell--curl
-curl $walleturl/$id/locked/$hash/$index -X PUT
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/locked/$hash/$index -X PUT
 ```
 
 ```javascript
@@ -2202,7 +2198,7 @@ index="0"
 ```
 
 ```shell--curl
-curl $walleturl/$id/locked/$hash/$index -X DELETE
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/locked/$hash/$index -X DELETE
 ```
 
 ```javascript
@@ -2267,7 +2263,7 @@ id="primary"
 ```
 
 ```shell--curl
-curl $walleturl/$id/locked
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/locked
 ```
 
 ```javascript
@@ -2332,7 +2328,7 @@ hsd-cli coin $hash $index
 ```
 
 ```shell--curl
-curl $walleturl/$id/coin/$hash/$index
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/coin/$hash/$index
 ```
 
 ```javascript

--- a/src/api-docs/source/includes/_wallet_accounts.md
+++ b/src/api-docs/source/includes/_wallet_accounts.md
@@ -49,7 +49,7 @@ id='primary'
 ```
 
 ```shell--curl
-curl $walleturl/$id/account
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/account
 ```
 
 ```shell--cli
@@ -110,7 +110,7 @@ account='default'
 ```
 
 ```shell--curl
-curl $walleturl/$id/account/$account
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/account/$account
 ```
 
 ```shell--cli
@@ -196,7 +196,7 @@ hsw-cli --id=$id account create --name=$name --type=$type --passphrase=$passphra
 ```
 
 ```shell--curl
-curl $walleturl/$id/account/$name \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/account/$name \
     -X PUT \
     --data '{"type": "'$type'", "passphrase": "'$passphrase'"}'
 ```

--- a/src/api-docs/source/includes/_wallet_admin.md
+++ b/src/api-docs/source/includes/_wallet_admin.md
@@ -2,10 +2,6 @@
 
 ```shell--curl
 curl http://x:api-key@127.0.0.1:14039 # will access admin functions for regtest (port 14039) wallets
-
-# examples in these docs will use an environment variable:
-walletadminurl=http://x:api-key@127.0.0.1:14039/
-curl $walletadminurl/<METHOD>
 ```
 
 Admin commands are simply commands not specific to any particular wallet,
@@ -28,7 +24,7 @@ height=50
 ```
 
 ```shell--curl
-curl $walletadminurl/rescan \
+curl http://x:api-key@127.0.0.1:14039/rescan \
   -X POST \
   --data '{"height": '$height'}'
 ```
@@ -70,7 +66,7 @@ Initiates a blockchain rescan for the walletdb. Wallets will be rolled back to t
 
 ## Wallet Resend
 ```shell--curl
-curl $walletadminurl/resend \
+curl http://x:api-key@127.0.0.1:14039/resend \
 -X POST
 ```
 
@@ -119,7 +115,7 @@ path='/home/user/walletdb-backup.ldb'
 ```
 
 ```shell--curl
-curl $walletadminurl/backup?path=$path \
+curl http://x:api-key@127.0.0.1:14039/backup?path=$path \
   -X POST
 ```
 
@@ -167,7 +163,7 @@ id='primary'
 ```
 
 ```shell--curl
-curl $walletadminurl/$id/master
+curl http://x:api-key@127.0.0.1:14039/$id/master
 ```
 
 ```shell--cli
@@ -247,7 +243,7 @@ id <br> _string_ | wallet id
 ## List all Wallets
 
 ```shell--curl
-curl $walletadminurl/wallet
+curl http://x:api-key@127.0.0.1:14039/wallet
 ```
 
 ```shell--cli

--- a/src/api-docs/source/includes/_wallet_auctions.md
+++ b/src/api-docs/source/includes/_wallet_auctions.md
@@ -8,7 +8,7 @@ id='primary'
 ```
 
 ```shell--curl
-curl $walleturl/$id/name
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/name
 ```
 
 ```shell--cli
@@ -89,7 +89,7 @@ name='handshake'
 ```
 
 ```shell--curl
-curl $walleturl/$id/name/$name
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/name/$name
 ```
 
 ```shell--cli
@@ -168,7 +168,7 @@ id='primary'
 ```
 
 ```shell--curl
-curl $walleturl/$id/auction
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/auction
 ```
 
 ```shell--cli
@@ -276,7 +276,7 @@ name='handshake'
 ```
 
 ```shell--curl
-curl $walleturl/$id/auction/$name
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/auction/$name
 ```
 
 ```shell--cli
@@ -383,7 +383,7 @@ own=true
 ```
 
 ```shell--curl
-curl $walleturl/$id/bid?own=$own
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/bid?own=$own
 ```
 
 ```shell--cli
@@ -453,7 +453,7 @@ own=false
 ```
 
 ```shell--curl
-curl $walleturl/$id/bid/$name?own=$own
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/bid/$name?own=$own
 ```
 
 ```shell--cli
@@ -534,7 +534,7 @@ own=false
 ```
 
 ```shell--curl
-curl $walleturl/$id/reveal?own=$own
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/reveal?own=$own
 ```
 
 ```shell--cli
@@ -614,7 +614,7 @@ own=false
 ```
 
 ```shell--curl
-curl $walleturl/$id/reveal/$name?own=$own
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/reveal/$name?own=$own
 ```
 
 ```shell--cli
@@ -694,7 +694,7 @@ name='handshake'
 ```
 
 ```shell--curl
-curl $walleturl/$id/resource/$name
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/resource/$name
 ```
 
 ```shell--cli
@@ -759,7 +759,7 @@ address='rs1q3qavv25ye6zsntszsj4awvq7gr4akq59k9y8hw'
 ```
 
 ```shell--curl
-curl "$walleturl/$id/nonce/$name?address=$address&bid=$bid"
+curl "http://x:api-key@127.0.0.1:14039/wallet/$id/nonce/$name?address=$address&bid=$bid"
 ```
 
 ```shell--cli
@@ -831,7 +831,7 @@ sign=true
 ```
 
 ```shell--curl
-curl $walleturl/$id/open \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/open \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",
@@ -947,7 +947,7 @@ lockup=4567000
 ```
 
 ```shell--curl
-curl $walleturl/$id/bid \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/bid \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",
@@ -1066,7 +1066,7 @@ sign=true
 ```
 
 ```shell--curl
-curl $walleturl/$id/reveal \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/reveal \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",
@@ -1199,7 +1199,7 @@ sign=true
 ```
 
 ```shell--curl
-curl $walleturl/$id/redeem \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/redeem \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",
@@ -1345,7 +1345,7 @@ value='Bread is a delicious food.'
 ```
 
 ```shell--curl
-curl $walleturl/$id/update \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/update \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",
@@ -1534,7 +1534,7 @@ sign=true
 ```
 
 ```shell--curl
-curl $walleturl/$id/renewal \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/renewal \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",
@@ -1661,7 +1661,7 @@ address='rs1qe4tnr7zhx95uvfw220k7eh9ke0rtducpp3hgjc'
 ```
 
 ```shell--curl
-curl $walleturl/$id/transfer \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/transfer \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",
@@ -1790,7 +1790,7 @@ sign=true
 ```
 
 ```shell--curl
-curl $walleturl/$id/cancel \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/cancel \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",
@@ -1920,7 +1920,7 @@ sign=true
 ```
 
 ```shell--curl
-curl $walleturl/$id/finalize \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/finalize \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",
@@ -2050,7 +2050,7 @@ sign=true
 ```
 
 ```shell--curl
-curl $walleturl/$id/revoke \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/revoke \
   -X POST \
   --data '{
     "passphrase":"'$passphrase'",

--- a/src/api-docs/source/includes/_wallet_rpc.md
+++ b/src/api-docs/source/includes/_wallet_rpc.md
@@ -1,11 +1,7 @@
 # RPC Calls - Wallet
 
 ```shell--curl
-# Examples in these docs will use a DIFFERENT environment variable
-# than the built-in hs-wallet API calls above:
-walletrpcurl=http://x:api-key@127.0.0.1:14039/
-
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{ "method": "<method>", "params": [...] "id": "some-id" }'
 ```
@@ -75,7 +71,7 @@ id='primary'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "selectwallet",
@@ -124,7 +120,7 @@ N. | Name | Default |  Description
 ## getwalletinfo
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{ "method": "getwalletinfo" }'
 ```
@@ -196,7 +192,7 @@ tx='0100000000024e61bc00000000001976a914fbdd46898a6d70a682cbd34420ccf0b6bb644937
 ```shell--curl
 options='{"changeAddress": "rs1qew8r8c2c74zpmkhwmxu6jkrhwmgegl5h6cfaz3", "feeRate": 0.001000}'
 
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "fundrawtransaction",
@@ -260,7 +256,7 @@ changeAddress | Handshake address for change output of transaction
 ## resendwallettransactions
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{ "method": "resendwallettransactions" }'
 ```
@@ -321,7 +317,7 @@ tx='a0a65cd0508450e8acae76f35ae622e7b1e7980e95f50026b98b2c6e025dae6c'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "abandontransaction",
@@ -377,7 +373,7 @@ path='/home/user/WalletBackup'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "backupwallet",
@@ -434,7 +430,7 @@ address='rs1qew8r8c2c74zpmkhwmxu6jkrhwmgegl5h6cfaz3'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "dumpprivkey",
@@ -492,7 +488,7 @@ path='/home/user-1/secretfiles/dump1.txt'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "dumpwallet",
@@ -568,7 +564,7 @@ passphrase='bikeshed'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "encryptwallet",
@@ -628,7 +624,7 @@ account='default'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "getaccountaddress",
@@ -685,7 +681,7 @@ address='rs1qew8r8c2c74zpmkhwmxu6jkrhwmgegl5h6cfaz3'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "getaccount",
@@ -742,7 +738,7 @@ account='default'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "getaddressesbyaccount",
@@ -796,7 +792,7 @@ N. | Name | Default |  Description
 ## getbalance
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{ "method": "getbalance" }'
 ```
@@ -850,7 +846,7 @@ account='default'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "getnewaddress",
@@ -899,7 +895,7 @@ N. | Name | Default |  Description
 ## getrawchangeaddress
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{ "method": "getrawchangeaddress" }'
 ```
@@ -954,7 +950,7 @@ minconf=6
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "getreceivedbyaccount",
@@ -1015,7 +1011,7 @@ minconf=6
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "getreceivedbyaddress",
@@ -1074,7 +1070,7 @@ txid='36cbb7ad0cc98ca86640a04c485f164dd741c20339af34516d359ecba2892c21'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "gettransaction",
@@ -1144,7 +1140,7 @@ N. | Name | Default |  Description
 ## getunconfirmedbalance
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{ "method": "getunconfirmedbalance" }'
 ```
@@ -1207,7 +1203,7 @@ rescan=false
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "importprivkey",
@@ -1267,7 +1263,7 @@ rescan=false
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "importwallet",
@@ -1325,7 +1321,7 @@ address='rs1qew8r8c2c74zpmkhwmxu6jkrhwmgegl5h6cfaz3'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "importaddress",
@@ -1390,7 +1386,7 @@ txoutproof='0000002006226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "importprunedfunds",
@@ -1452,7 +1448,7 @@ pubkey='02548e0a23b90505f1b4017f52cf2beeaa399fce7ff2961e29570c6afdfa9bfc5b'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "importpubkey",
@@ -1511,7 +1507,7 @@ watchonly=false
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "listaccounts",
@@ -1581,7 +1577,7 @@ unlock=false
 ```shell--curl
 outputs='[{ "txid": "3962a06342fc62a733700d74c075a5d24c4f44f7108f6d9a318b66e92e3bdc72", "vout": 1 }]'
 
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "lockunspent",
@@ -1637,7 +1633,7 @@ N. | Name | Default |  Description
 ## listlockunspent
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{ "method": "listlockunspent" }'
 ```
@@ -1699,7 +1695,7 @@ watchOnly=true
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "listreceivedbyaccount",
@@ -1782,7 +1778,7 @@ watchOnly=false
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "listreceivedbyaddress",
@@ -1869,7 +1865,7 @@ watchOnly=false
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "listsinceblock",
@@ -1984,7 +1980,7 @@ account='hot'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "listtransactions",
@@ -2102,7 +2098,7 @@ maxconf=20
 addrs='["rs1q3qm3e6sxd0mzax54jx6p3th0p2adzxdx2tm3zl"]'
 
 
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "listunspent",
@@ -2176,7 +2172,7 @@ amount=0.0195
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "sendfrom",
@@ -2241,7 +2237,7 @@ subtractfee=false
 ```shell--curl
 outputs='{"rs1qkk62444euknkya4qws9cg3ej3au24n635n4qye": 0.123, "rs1qew8r8c2c74zpmkhwmxu6jkrhwmgegl5h6cfaz3": 0.321}'
 
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "sendmany",
@@ -2308,7 +2304,7 @@ subtractfee=true
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "sendtoaddress",
@@ -2368,7 +2364,7 @@ rate=0.001
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "settxfee",
@@ -2427,7 +2423,7 @@ message='Satoshi'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "signmessage",
@@ -2480,7 +2476,7 @@ N. | Name | Default |  Description
 ## walletlock
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{ "method": "walletlock" }'
 ```
@@ -2536,7 +2532,7 @@ passphrase='CorrectHorseBatteryStaple'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "walletpassphrasechange",
@@ -2595,7 +2591,7 @@ timeout=600
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "walletpassphrase",
@@ -2653,7 +2649,7 @@ txid='6478cafe0c91e5ed4c55ade3b1726209caa0d290c8a3a84cc345caad60073ad5'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "removeprunedfunds",
@@ -2703,7 +2699,7 @@ N. | Name | Default |  Description
 ## wallet getmemoryinfo
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{ "method": "getmemoryinfo" }'
 ```
@@ -2764,7 +2760,7 @@ level='debug'
 ```
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{
     "method": "setloglevel",
@@ -2816,7 +2812,7 @@ N. | Name | Default |  Description
 ## wallet stop
 
 ```shell--curl
-curl $walletrpcurl \
+curl http://x:api-key@127.0.0.1:14039 \
   -X POST \
   --data '{ "method": "stop" }'
 ```

--- a/src/api-docs/source/includes/_wallet_tx.md
+++ b/src/api-docs/source/includes/_wallet_tx.md
@@ -16,7 +16,7 @@ hsw-cli --id=$id tx $hash
 ```
 
 ```shell--curl
-curl $walleturl/$id/tx/$hash
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/tx/$hash
 ```
 
 ```javascript
@@ -126,7 +126,7 @@ hash="a97a9993389ae321b263dffb68ba1312ad0655da83aeca75b2372d5abc70544a"
 ```
 
 ```shell--curl
-curl $walleturl/$id/tx/$hash \
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/tx/$hash \
   -X DELETE
 ```
 
@@ -161,7 +161,7 @@ hsw-cli --id=$id history
 ```
 
 ```shell--curl
-curl $walleturl/$id/tx/history
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/tx/history
 ```
 
 ```javascript
@@ -274,7 +274,7 @@ hsw-cli --id=$id pending
 ```
 
 ```shell--curl
-curl $walleturl/$id/tx/unconfirmed
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/tx/unconfirmed
 ```
 
 ```javascript
@@ -326,7 +326,7 @@ end="1527186612"
 ```
 
 ```shell--curl
-curl $walleturl/$id/tx/range?start=$start'&'end=$end
+curl http://x:api-key@127.0.0.1:14039/wallet/$id/tx/range?start=$start'&'end=$end
 ```
 
 ```javascript

--- a/src/api-docs/source/index.html.md
+++ b/src/api-docs/source/index.html.md
@@ -53,10 +53,6 @@ The default hsd HTTP server listens on port (`12037` for main, `13037` for testn
 ```shell--curl
 # default regtest port is 14037 (may be reconfigured by user), API key is required in URL
 curl http://x:api-key@127.0.0.1:14037/
-
-# examples in these docs will use an environment variable:
-url=http://x:api-key@127.0.0.1:14037/
-curl $url
 ```
 
 ```shell--cli

--- a/src/api-docs/source/stylesheets/_variables.scss
+++ b/src/api-docs/source/stylesheets/_variables.scss
@@ -98,6 +98,5 @@ $search-box-border-color: #666 !default;
 // These settings are probably best left alone.
 
 %break-words {
-    word-break: break-all;
-    hyphens: auto;
+    word-break: break-word;
 }

--- a/src/templates/layout.html
+++ b/src/templates/layout.html
@@ -34,7 +34,7 @@
     <li><a id="guides-claims" $if(active-guides-claims)$ class="active" $else$ $endif$ href="/guides/claims.html">Name Claims</a></li>
     <li><a id="guides-auctions" $if(active-guides-auctions)$ class="active" $else$ $endif$ href="/guides/auctions.html">Name Auctions</a></li>
     <li><a id="guides-wallet" $if(active-guides-wallet)$ class="active" $else$ $endif$ href="/guides/wallet.html">Wallet Setup</a></li>
-    <li><a id="guides-protocol" $if(active-guides-wallet)$ class="active" $else$ $endif$ href="/guides/protocol.html">Protocol Summary</a></li>
+    <li><a id="guides-protocol" $if(active-guides-protocol)$ class="active" $else$ $endif$ href="/guides/protocol.html">Protocol Summary</a></li>
   </ul>
   <ul>
     <li><strong>DOCUMENTATION</strong></li>


### PR DESCRIPTION
I added a long intro to the API docs covering most of the FAQs we get from new developers using the hsd API for the first time.

In addition, I replaced all the `curl $url` stuff with the explicit path. It's too hard to find what `$url` stores in the docs, and it makes the examples impossible to copy-paste unless you've already set the environment variable