### PR TITLE
guides: remove sample hsd.conf from configuration guide

### DIFF
--- a/src/guides/config.md
+++ b/src/guides/config.md
@@ -177,9 +177,15 @@ $ HSD_NETWORK=testnet HSD_HTTP_HOST=0.0.0.0 HSD_WALLET_HTTP_HOST=0.0.0.0 HSD_WAL
 ### Example configuration file
 
 The following file could be placed at `~/.hsd/hsd.conf` for use with a mainnet hsd node.
+It could (for example) be placed at `~/.hsd/testnet/hsd.conf` if the node is started with `hsd --network=testnet`.
 All the settings in the example below are defaults, meaning you do NOT need to use
 this `hsd.conf` if you do not need to change any of the values. It is
-provided only as an example of the configuration file syntax.
+provided only as an example of the configuration file syntax:
+
+- Configuration options are newline delimited.
+- The key/value pairs are delimited by a colon.
+- All options can be set via command line, environment variable or the config file.
+(See top of page)
 
 ```
 max-inbound: 8

--- a/src/guides/config.md
+++ b/src/guides/config.md
@@ -173,3 +173,21 @@ $ HSD_NETWORK=testnet HSD_HTTP_HOST=0.0.0.0 HSD_WALLET_HTTP_HOST=0.0.0.0 HSD_WAL
 - `no-auth`: Disable auth for API server and wallets (default: false).
 - `wallet-auth`: Enable token auth for wallets (default: false).
 - `admin-token`: Token required if `wallet-auth` is enabled: restricts access to [all wallet admin routes.](https://handshake-org.github.io/api-docs/#wallet-admin-commands)
+
+### Example configuration file
+
+The following file could be placed at `~/.hsd/hsd.conf` for use with a mainnet hsd node.
+All the settings in the example below are defaults, meaning you do NOT need to use
+this `hsd.conf` if you do not need to change any of the values. It is
+provided only as an example of the configuration file syntax.
+
+```
+max-inbound: 8
+max-outbound: 8
+log-level: debug
+prune: false
+checkpoints: true
+rs-port: 5350
+```
+
+

--- a/src/guides/config.md
+++ b/src/guides/config.md
@@ -173,8 +173,3 @@ $ HSD_NETWORK=testnet HSD_HTTP_HOST=0.0.0.0 HSD_WALLET_HTTP_HOST=0.0.0.0 HSD_WAL
 - `no-auth`: Disable auth for API server and wallets (default: false).
 - `wallet-auth`: Enable token auth for wallets (default: false).
 - `admin-token`: Token required if `wallet-auth` is enabled: restricts access to [all wallet admin routes.](https://handshake-org.github.io/api-docs/#wallet-admin-commands)
-
-
-## Sample Config Files
-
-See https://github.com/handshake-org/hsd/blob/master/etc/sample.conf


### PR DESCRIPTION
Closes https://github.com/handshake-org/handshake-org.github.io/issues/72

the sample hsd.conf was removed in https://github.com/handshake-org/hsd/commit/299aa7b3e6189a006a03dfe1f229d171195c9028