### PR TITLE
Add ssl to javascript client connection

### DIFF
--- a/src/api-docs/source/includes/_clients.md
+++ b/src/api-docs/source/includes/_clients.md
@@ -117,4 +117,5 @@ network   | _string_ | Network to use: `main`, `testnet`, `regtest`
 port      | _int_                          | hsd socket port (defaults specific for each network)
 host      | _string_ | hsd API host URI (defaults to 127.0.0.1)
 apiKey    | _string_                       | API secret
+ssl       | _boolean_                      | TLS (defaults to false: `http`, unless url has `https`)
 


### PR DESCRIPTION
https://hsd-dev.org/api-docs/#using-javascript-clients,  Connecting to nodes that have SSL( https) enabled is using hs-client needs to be specified in the API documentation as seen in the guide https://hsd-dev.org/guides/config.html