### PR TITLE
Clarify that a nameserver is needed

### DIFF
--- a/src/guides/resource-records.md
+++ b/src/guides/resource-records.md
@@ -9,6 +9,10 @@ so that proofs can be served to light clients.
 Each Handshake name stores a single `Resource` with the maximum size of
 512 bytes.
 
+Note that the blockchain records are designed to be referral-only, meaning
+you'll need a conventional nameserver running somewhere to host records like
+A, AAAA, CNAME, etc.
+
 ### Updating Resource Records
 
 To update the resource records associated with a name, the wallet RPC


### PR DESCRIPTION
Since most handshake users will just be interested in getting a website online for their new name, this guide should clarify that for regular DNS records like A, AAAA, CNAME, etc. a conventional nameserver is necessary for the chain to refer to.