### PR TITLE
Remove 'network' from options passed to Javascript clients.

### DIFF
--- a/src/api-docs/source/includes/_clients.md
+++ b/src/api-docs/source/includes/_clients.md
@@ -89,13 +89,11 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -113,7 +111,6 @@ Custom port numbers are also configurable by the user.
 
 Config    | Type                         | Description
 --------- | -----------                  | -----------
-network   | _string_ | Network to use: `main`, `testnet`, `regtest`
 port      | _int_                          | hsd socket port (defaults specific for each network)
 host      | _string_ | hsd API host URI (defaults to 127.0.0.1)
 apiKey    | _string_                       | API secret

--- a/src/api-docs/source/includes/_coin.md
+++ b/src/api-docs/source/includes/_coin.md
@@ -41,7 +41,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -111,7 +110,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -205,7 +203,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_node.md
+++ b/src/api-docs/source/includes/_node.md
@@ -41,7 +41,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -130,7 +129,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -267,7 +265,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -437,7 +434,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -495,7 +491,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -550,7 +545,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -608,7 +602,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_node_rpc.md
+++ b/src/api-docs/source/includes/_node_rpc.md
@@ -16,7 +16,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_node_rpc_block.md
+++ b/src/api-docs/source/includes/_node_rpc_block.md
@@ -18,7 +18,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -90,7 +89,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -137,7 +135,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -196,7 +193,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -286,7 +282,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -374,7 +369,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -432,7 +426,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -499,7 +492,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -555,7 +547,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_node_rpc_chain.md
+++ b/src/api-docs/source/includes/_node_rpc_chain.md
@@ -21,7 +21,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -79,7 +78,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -135,7 +133,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_node_rpc_general.md
+++ b/src/api-docs/source/includes/_node_rpc_general.md
@@ -17,7 +17,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -63,7 +62,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -127,7 +125,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -183,7 +180,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -241,7 +237,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -309,7 +304,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -370,7 +364,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -431,7 +424,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -491,7 +483,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_node_rpc_mempool.md
+++ b/src/api-docs/source/includes/_node_rpc_mempool.md
@@ -20,7 +20,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -84,7 +83,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -189,7 +187,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -293,7 +290,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -367,7 +363,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -463,7 +458,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -525,7 +519,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -582,7 +575,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -639,7 +631,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -699,7 +690,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_node_rpc_mining.md
+++ b/src/api-docs/source/includes/_node_rpc_mining.md
@@ -32,7 +32,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -82,7 +81,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -148,7 +146,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -210,7 +207,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -268,7 +264,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -378,7 +373,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -428,7 +422,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -483,7 +476,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -533,7 +525,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -590,7 +581,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -657,7 +647,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_node_rpc_names.md
+++ b/src/api-docs/source/includes/_node_rpc_names.md
@@ -18,7 +18,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -108,7 +107,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -192,7 +190,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -239,7 +236,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -286,7 +282,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -367,7 +362,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -417,7 +411,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -458,7 +451,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -512,7 +504,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -567,7 +558,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -610,7 +600,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_node_rpc_network.md
+++ b/src/api-docs/source/includes/_node_rpc_network.md
@@ -21,7 +21,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -68,7 +67,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -117,7 +115,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -204,7 +201,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -270,7 +266,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -327,7 +322,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -387,7 +381,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -440,7 +433,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -519,7 +511,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -575,7 +566,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -631,7 +621,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_node_rpc_tx.md
+++ b/src/api-docs/source/includes/_node_rpc_tx.md
@@ -31,7 +31,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -92,7 +91,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -158,7 +156,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -216,7 +213,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -324,7 +320,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -385,7 +380,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -451,7 +445,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -543,7 +536,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -620,7 +612,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -679,7 +670,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_node_sockets.md
+++ b/src/api-docs/source/includes/_node_sockets.md
@@ -80,7 +80,6 @@ const {Network, ChainEntry} = require('hsd');
 const network = Network.get('regtest');
 
 const nodeOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: '<api-key>'
 }

--- a/src/api-docs/source/includes/_transaction.md
+++ b/src/api-docs/source/includes/_transaction.md
@@ -32,7 +32,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -125,7 +124,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }
@@ -233,7 +231,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_wallet.md
+++ b/src/api-docs/source/includes/_wallet.md
@@ -11,7 +11,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -93,7 +92,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -172,7 +170,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -272,7 +269,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -370,7 +366,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -426,7 +421,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -500,7 +494,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -589,7 +582,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -669,7 +661,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -822,7 +813,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -956,7 +946,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1075,7 +1064,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1147,7 +1135,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1211,7 +1198,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1279,7 +1265,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1358,7 +1343,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1417,7 +1401,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1470,7 +1453,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1536,7 +1518,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1606,7 +1587,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1675,7 +1655,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1739,7 +1718,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1797,7 +1775,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1865,7 +1842,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1907,72 +1883,6 @@ Parameter | Description
 --------- | -------------
 account <br>_string_ | BIP44 account to generate address from
 
-## Derive Nested Address
-
-```javascript
-let id, account;
-```
-
-```shell--vars
-id="witness1"
-account='default'
-```
-
-```shell--cli
-hsw-cli --id=$id nested --account=$account
-```
-
-```shell--curl
-curl http://x:api-key@127.0.0.1:14039/wallet/$id/nested -X POST --data '{"account": "'$account'"}'
-```
-
-```javascript
-const {WalletClient} = require('hs-client');
-const {Network} = require('hsd');
-const network = Network.get('regtest');
-
-const walletOptions = {
-  network: network.type,
-  port: network.walletPort,
-  apiKey: 'api-key'
-}
-
-const walletClient = new WalletClient(walletOptions);
-const wallet = walletClient.wallet(id);
-
-(async () => {
-  const result = await wallet.createNested(account);
-  console.log(result);
-})();
-```
-
-> Sample response
-
-```json
-{
-  "name": "default",
-  "account": 0,
-  "branch": 1,
-  "index": 6,
-  "publicKey": "0232b907306e5bea1899874b813aed4e82eace6cb75c2a039434ce81576cf299c7",
-  "script": null,
-  "address": "rs1q30ppv5gyrwpy4wyk0v6uzawxygdtvrpux8yrg2"
-}
-```
-
-Derive new nested p2sh receiving address for account. Note that this can't be done on a non-witness account otherwise you will receive the following error:
-
-`[error] (node) Cannot derive nested on non-witness account.`
-
-### HTTP Request
-
-`POST /wallet/:id/nested`
-
-### Post Paramters
-Paramter | Description
---------- | --------------
-account <br> _string_ | account to derive the nested address for (default='default')
-
 ## Get Balance
 ```javascript
 let id, account;
@@ -1997,7 +1907,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2062,7 +1971,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2141,7 +2049,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2207,7 +2114,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2272,7 +2178,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2337,7 +2242,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_wallet_accounts.md
+++ b/src/api-docs/source/includes/_wallet_accounts.md
@@ -62,7 +62,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -123,7 +122,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -207,7 +205,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_wallet_admin.md
+++ b/src/api-docs/source/includes/_wallet_admin.md
@@ -39,7 +39,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -80,7 +79,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -129,7 +127,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -176,7 +173,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -256,7 +252,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_wallet_auctions.md
+++ b/src/api-docs/source/includes/_wallet_auctions.md
@@ -21,7 +21,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -102,7 +101,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -181,7 +179,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -289,7 +286,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -396,7 +392,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -466,7 +461,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -547,7 +541,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -627,7 +620,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -707,7 +699,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -772,7 +763,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -851,7 +841,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -969,7 +958,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1086,7 +1074,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1219,7 +1206,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1366,7 +1352,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1554,7 +1539,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1682,7 +1666,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1810,7 +1793,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1940,7 +1922,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2070,7 +2051,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_wallet_rpc.md
+++ b/src/api-docs/source/includes/_wallet_rpc.md
@@ -16,7 +16,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -89,7 +88,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -135,7 +133,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -212,7 +209,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -271,7 +267,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -335,7 +330,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -391,7 +385,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -448,7 +441,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -506,7 +498,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -582,7 +573,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -642,7 +632,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -699,7 +688,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -756,7 +744,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -807,7 +794,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -864,7 +850,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -910,7 +895,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -968,7 +952,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1029,7 +1012,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1088,7 +1070,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1155,7 +1136,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1175,13 +1155,6 @@ const walletClient = new WalletClient(walletOptions);
 ```
 
 Get the unconfirmed balance from the wallet.
-<aside class="notice">
-In hsd balances, <code>confirmed</code> refers to the total balance of coins
-confirmed in the blockchain. <code>unconfirmed</code> refers to that total
-IN ADDITION to any transactions still unconfirmed in the mempool.
-Another way to think about it is your <code>unconfirmed</code> balance is the
-FUTURE total value of your wallet after everything is confirmed.
-</aside>
 
 ### Params
 N. | Name | Default |  Description
@@ -1221,7 +1194,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1281,7 +1253,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1342,7 +1313,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1404,7 +1374,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1466,7 +1435,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1525,7 +1493,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1600,7 +1567,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1648,7 +1614,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1713,7 +1678,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1796,7 +1760,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1883,7 +1846,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1998,7 +1960,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2118,7 +2079,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2190,7 +2150,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2257,7 +2216,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2322,7 +2280,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2382,7 +2339,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2441,7 +2397,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2491,7 +2446,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2550,7 +2504,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2609,7 +2562,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2667,7 +2619,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2714,7 +2665,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2778,7 +2728,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -2827,7 +2776,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_wallet_rpc_auctions.md
+++ b/src/api-docs/source/includes/_wallet_rpc_auctions.md
@@ -13,7 +13,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -124,7 +123,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -190,7 +188,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -251,7 +248,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -314,7 +310,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -403,7 +398,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -492,7 +486,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -604,7 +597,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -705,7 +697,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -800,7 +791,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -905,7 +895,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1012,7 +1001,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1115,7 +1103,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1217,7 +1204,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1320,7 +1306,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -1366,7 +1351,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/includes/_wallet_sockets.md
+++ b/src/api-docs/source/includes/_wallet_sockets.md
@@ -75,7 +75,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: '<api-key>'
 }

--- a/src/api-docs/source/includes/_wallet_tx.md
+++ b/src/api-docs/source/includes/_wallet_tx.md
@@ -25,7 +25,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -170,7 +169,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -283,7 +281,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }
@@ -335,7 +332,6 @@ const {Network} = require('hsd');
 const network = Network.get('regtest');
 
 const walletOptions = {
-  network: network.type,
   port: network.walletPort,
   apiKey: 'api-key'
 }

--- a/src/api-docs/source/index.html.md
+++ b/src/api-docs/source/index.html.md
@@ -172,6 +172,13 @@ they can not be recovered using the BIP44 process (which is computed exclusively
 a seed phrase plus blockchain data). [This issue is well-known](https://github.com/handshake-org/hsd/issues/378)
 and some solutions have been proposed to assist in wallet recovery of blinded bid data.
 
+<aside class="notice">
+In hsd balances, <code>confirmed</code> refers to the total balance of coins
+confirmed in the blockchain. <code>unconfirmed</code> refers to that total
+IN ADDITION to any transactions still unconfirmed in the mempool.
+Another way to think about it is your <code>unconfirmed</code> balance is the
+FUTURE total value of your wallet after everything is confirmed.
+</aside>
 
 # Authentication
 ## Auth
@@ -197,7 +204,6 @@ const network = Network.get('regtest');
 
 // network type derived from hsd object, client object stores API key
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }

--- a/src/guides/events.md
+++ b/src/guides/events.md
@@ -211,7 +211,6 @@ const {Network, ChainEntry} = require('hsd');
 const network = Network.get('regtest');
 
 const clientOptions = {
-  network: network.type,
   port: network.rpcPort,
   apiKey: 'api-key'
 }


### PR DESCRIPTION
Remove unused 'network' option passed to Javascript clients.

It closes #92