### PR TITLE
Deploy PRs to Sia

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,3 +37,9 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build
         cname: hsd-dev.org
+    - name: Deploy to Skynet
+      uses: kwypchlo/deploy-to-skynet-action@main
+      with:
+          upload-dir: ./build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          registry-seed: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && secrets.REGISTRY_SEED || '' }}


### PR DESCRIPTION
Now, each PR will build the docs, send to SIA and add a comment to the PR.
It only publish to the `gh-pages` once merged to master