### PR TITLE
Bundle installing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ tramp
 _site/
 
 /build
+.bundle

--- a/bin/build
+++ b/bin/build
@@ -28,5 +28,5 @@ echo 'finished'
 # build API documentation
 echo 'building api documentation...'
 cd ./src/api-docs
-bundle install
+bundle install --path=../../build/vendor
 bundle exec middleman build --clean --build-dir=../../build/api-docs


### PR DESCRIPTION
I noticed when you try to run `./bin/build` it will try to install dependencies, but on my machine (Not sure about others)
it tries to install in system folder, which then requires su to have access.

So this is the fix for that issue.
Also `.bundle` is generated at `src/api-docs/.bundle` if you specify custom `vendor`.