### PR TITLE
Hsd docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,16 +20,6 @@ jobs:
         bundler-cache: true
 
     - run: ./bin/build
-    # - uses: actions/checkout@v2
-    #   with:
-    #     repository: handshake-org/hsd
-    #     ref: e270b8cef3f4552c35f744d04594ebe8896d5141
-    #     path: hsd
-    # - run: |
-    #     cd hsd
-    #     npm install -g jsdoc
-    #     jsdoc -c jsdoc.json
-    #     cp -r ./docs/reference ../build/docs
     - name: Deploy
       if: github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v3

--- a/bin/build-docs
+++ b/bin/build-docs
@@ -27,5 +27,5 @@ echo "building docs"
 rm -rf docs
 jsdoc -c jsdoc.json
 cd $destDir
-rm -rf ./docs
-cp -r "$buildDir/docs/reference" ./docs
+rm -rf ./hsd
+cp -r "$buildDir/docs/reference" ./hsd

--- a/bin/build-docs
+++ b/bin/build-docs
@@ -27,5 +27,5 @@ echo "building docs"
 rm -rf docs
 jsdoc -c jsdoc.json
 cd $destDir
-rm -rf ./hsd
-cp -r "$buildDir/docs/reference" ./hsd
+rm -rf ./build/hsd
+cp -r "$buildDir/docs/reference" ./build/hsd

--- a/src/templates/layout.html
+++ b/src/templates/layout.html
@@ -41,7 +41,7 @@
   <ul>
     <li><strong>DOCUMENTATION</strong></li>
     <li><a href="/api-docs">API Docs</a></li>
-    <li><a href="/docs">Full Documentation</a></li>
+    <li><a href="/hds">Full Documentation</a></li>
   </ul>
   <ul>
     <li><strong>PROTOCOL</strong></li>

--- a/src/templates/layout.html
+++ b/src/templates/layout.html
@@ -41,7 +41,7 @@
   <ul>
     <li><strong>DOCUMENTATION</strong></li>
     <li><a href="/api-docs">API Docs</a></li>
-    <li><a href="/hds">Full Documentation</a></li>
+    <li><a href="/hsd">Full Documentation</a></li>
   </ul>
   <ul>
     <li><strong>PROTOCOL</strong></li>


### PR DESCRIPTION
1. No need to have it on GH Actions
2. `bin/build-docs` still works for building hsd docs locally