### PR TITLE
Fix hsd client config

### DIFF
--- a/src/guides/config.md
+++ b/src/guides/config.md
@@ -165,11 +165,10 @@ $ HSD_NETWORK=testnet HSD_HTTP_HOST=0.0.0.0 HSD_WALLET_HTTP_HOST=0.0.0.0 HSD_WAL
 ```
 
 ### hsd client:
-
-- `node-host`: Location of hsd node HTTP server (default: localhost).
-- `node-port`: Port of hsd node HTTP server (defaults to RPC port of network).
-- `node-ssl`: Whether to use SSL (default: false).
-- `node-api-key`: API-key for hsd HTTP server.
+- `http-host`: Location of hsd node HTTP server (default: localhost).
+- `http-port`: Port of hsd node HTTP server (defaults to RPC port of network).
+- `ssl`: Whether to use SSL (default: false).
+- `api-key`: API-key for hsd HTTP server.
 
 ### Wallet database:
 


### PR DESCRIPTION
The current config parameters are not working with hs-client and hsd-cli.

These parameters do work:
https://github.com/handshake-org/hs-client/blob/d82611cead27d7f9586d878438a23ad2005ff8af/bin/hsd-cli#L41

I don't understand the difference between "url" and "http-host". I think they are the same.