### PR TITLE
Fix hsd installation doc URLs

### DIFF
--- a/src/guides/linux-install.md
+++ b/src/guides/linux-install.md
@@ -9,7 +9,7 @@ requirements of running a full node.
 ### `hsd`
 
 To install `hsd`, follow the instructions
-[here](https://github.com/handshake-org/hsd#install).
+[here](https://github.com/handshake-org/hsd/blob/master/docs/install.md).
 
 ### `hnsd`
 

--- a/src/guides/linux-install_sp.md
+++ b/src/guides/linux-install_sp.md
@@ -11,7 +11,7 @@ sin los requisitos de recursos informáticos de ejecutar un nodo completo.
 ### `hsd`
 
 Para instalar `hsd`, siga las instrucciones
-[aquí](https://github.com/handshake-org/hsd#install).
+[aquí](https://github.com/handshake-org/hsd/blob/master/docs/install.md).
 
 ### `hnsd`
 

--- a/src/guides/mac-install.md
+++ b/src/guides/mac-install.md
@@ -9,7 +9,7 @@ requirements of running a full node.
 ### `hsd`
 
 To install `hsd`, follow the instructions
-[here](https://github.com/handshake-org/hsd#install).
+[here](https://github.com/handshake-org/hsd/blob/master/docs/install.md).
 
 ### `hnsd`
 

--- a/src/guides/mac-install_sp.md
+++ b/src/guides/mac-install_sp.md
@@ -11,7 +11,7 @@ sin los requisitos de recursos informáticos de ejecutar un nodo completo.
 ### `hsd`
 
 Para instalar `hsd`, siga las instrucciones
-[aquí](https://github.com/handshake-org/hsd#install).
+[aquí](https://github.com/handshake-org/hsd/blob/master/docs/install.md).
 
 ### `hnsd`
 

--- a/src/guides/win-install.md
+++ b/src/guides/win-install.md
@@ -11,7 +11,7 @@ requirements of running a full node.
 ### `hsd`
 
 To install `hsd`, follow the instructions
-[here](https://github.com/handshake-org/hsd#install).
+[here](https://github.com/handshake-org/hsd/blob/master/docs/install.md).
 
 ### `hnsd`
 

--- a/src/guides/win-install_sp.md
+++ b/src/guides/win-install_sp.md
@@ -11,7 +11,7 @@ sin los requisitos de recursos informáticos de ejecutar un nodo completo.
 ### `hsd`
 
 Para instalar `hsd`, siga las instrucciones
-[aquí](https://github.com/handshake-org/hsd#install).
+[aquí](https://github.com/handshake-org/hsd/blob/master/docs/install.md).
 
 ### `hnsd`
 


### PR DESCRIPTION
Should've been done along with https://github.com/handshake-org/hsd/commit/0a5a2608e86baf39145ae5528008082e505b5b3a (during https://github.com/handshake-org/hsd/pull/663).