### PR TITLE
protocol: Clarify revoked name delay in summary.md

### DIFF
--- a/src/protocol/summary.md
+++ b/src/protocol/summary.md
@@ -138,7 +138,7 @@ can still be changed.
 Transfers are locked for
 [about two days](https://github.com/handshake-org/hsd/blob/56c83ca7344def512ef861f452bff91d43bc8f52/lib/protocol/networks.js#L319)
 before `FINALIZE` is allowed. At any point during that phase, the original owner can `REVOKE`.
-A revoked name can be re-opened with a new auction after it expires, but the current
+A revoked name can be re-opened with a new auction after ~29 days (4176 blocks), but the current
 chain of ownership is terminated.
 
 Names must be renewed within


### PR DESCRIPTION
The old revoke summary was not very clear about when someone can reopen the domain for auction after a revoke.

> A revoked name can be re-opened with a new auction after it expires, but the current chain of ownership is terminated.

This seems to say the auction can only be opened 2 years after the previous heartbeat (aka the domain expires)

@rithvikvibhu double checked this in the code and the domain is ready to auction after only ~29 days from the revoke


The check to see if the domain is ready to auction uses `AuctionMaturity`:

> height < this.revoked + network.names.auctionMaturity

From https://github.com/handshake-org/hsd/blob/0a4f24bdb0cc93b1d0236c77966085b305fe3d71/lib/covenants/namestate.js#L203

And `AuctionMaturity` is:

> auctionMaturity: (5 + 10 + 14) * main.pow.blocksPerDay

From https://github.com/handshake-org/hsd/blob/0a4f24bdb0cc93b1d0236c77966085b305fe3d71/lib/protocol/networks.js#L370